### PR TITLE
Add default.argdef file.

### DIFF
--- a/src/main/resources/default.argdef
+++ b/src/main/resources/default.argdef
@@ -1,0 +1,13 @@
+<operator>.assignment, 1
+<operator>.assignmentAnd, 1
+<operators>.assignmentArithmeticShiftRight, 1
+<operator>.assignmentDivision, 1
+<operators>.assignmentExponentiation, 1
+<operators>.assignmentLogicalShifRight, 1
+<operator>.assignmentMinus, 1
+<operators>.assignmentModulo, 1
+<operator>.assignmentMultiplication, 1
+<operators>.assignmentOr, 1
+<operator>.assignmentPlus, 1
+<operators>.assignmentShiftLeft, 1
+<operators>.assignmentXor, 1

--- a/src/main/scala/io/shiftleft/Main.scala
+++ b/src/main/scala/io/shiftleft/Main.scala
@@ -4,7 +4,7 @@ import io.shiftleft.cpgloading.CpgLoader
 
 
 object Main extends App {
-  val cpg = CpgLoader.loadCodePropertyGraph(args(0))
+  val cpg = CpgLoader.loadCodePropertyGraph(args(0), Some("src/main/resources/default.argdef"))
   implicit val graph = cpg.graph
 
   println("------------------")


### PR DESCRIPTION
Required by new codepropertygraph library which does not provide
semantics any more.