### PR TITLE
Generation of API documentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,3 +12,74 @@ libraryDependencies ++= Seq(
 )
 
 enablePlugins(JavaAppPackaging)
+
+lazy val generateScaladocs = taskKey[File]("generate scaladocs from combined project sources")
+generateScaladocs := {
+
+  import better.files._
+  import java.io.{File => JFile, PrintWriter}
+  import org.zeroturnaround.zip.ZipUtil
+  import sbt.internal.inc.AnalyzingCompiler
+  import sbt.internal.util.Attributed.data
+  import sbt.internal.CommandStrings.ExportStream
+
+  val updateReport = updateClassifiers.value
+  val label = "Joern API documentation"
+  val s = streams.value
+  val out = target.value / "api"
+  val fiOpts = (Compile/doc/fileInputOptions).value
+
+   val sOpts = Seq(
+    "-language:implicitConversions",
+    "-doc-root-content", "api-doc-root.txt",
+    "-implicits")
+
+  val xapis = apiMappings.value
+  val options = sOpts ++ Opts.doc.externalAPI(xapis)
+  val cp = data((Compile/dependencyClasspath).value).toList
+
+  val inputFilesRelativeDir = target.value + "/inputFiles"
+  val inputFiles = File(inputFilesRelativeDir)
+  if (inputFiles.exists) inputFiles.delete()
+  inputFiles.createDirectory()
+
+   /* extract sources-jar dependencies */
+  List(
+    "codepropertygraph",
+    "query-primitives",
+    "enhancements",
+    "semanticcpg"
+  ).foreach { projectName =>
+    ZipUtil.unpack(
+      SbtHelper.findJar(projectName, updateReport, SbtHelper.JarClassifier.Sources),
+      inputFiles.toJava)
+  }
+
+
+  // slightly adapted from sbt's Default.scala `docTaskSettings`
+  val srcs: Seq[JFile] =
+    inputFiles.listRecursively
+      .filter { file =>
+        file.extension == Some(".java") || file.extension == Some(".scala")
+      }
+      .map(_.toJava)
+      .toSeq
+
+  def exportedPW(w: PrintWriter, command: String): Seq[String] => Unit =
+    args => w.println((command +: args).mkString(" "))
+
+  def exportedTS(s: TaskStreams, command: String): Seq[String] => Unit = args => {
+    val w = s.text(ExportStream)
+    try exportedPW(w, command)
+    finally w.close()
+  }
+
+
+  val runDoc = Doc.scaladoc(label, s.cacheStoreFactory.sub("scala"), compilers.value.scalac match {
+    case ac: AnalyzingCompiler => ac.onArgs(exportedTS(s, "scaladoc"))
+  }, fiOpts)
+
+  runDoc(srcs, cp, out, options, maxErrors.value, s.log)
+
+  out
+}

--- a/project/SbtHelper.scala
+++ b/project/SbtHelper.scala
@@ -1,0 +1,30 @@
+import java.io.{File => JFile}
+import sbt.librarymanagement.UpdateReport
+
+object SbtHelper {
+
+  object JarClassifier extends Enumeration {
+    type JarClassifier = Value
+    val Classes, Sources, Javadoc = Value
+  }
+
+  def findJar(artifactName: String, report: UpdateReport, jarClassifier: JarClassifier.Value): JFile = {
+    val jarOption =
+      report.configurations.filter(_.configuration.name == "compile").flatMap { config =>
+        config.modules.filter(_.module.name == artifactName).flatMap { module =>
+          val wantedClassifier = jarClassifier match {
+            case JarClassifier.Classes => None
+            case JarClassifier.Sources => Some("sources")
+            case JarClassifier.Javadoc => Some("javadoc")
+          }
+          module.artifacts.collect {
+            case (artifact, file) if artifact.classifier == wantedClassifier => file
+          }
+        }
+      }.headOption
+
+    assert(jarOption.isDefined, s"jar for $artifactName not found")
+    jarOption.get
+  }
+}
+

--- a/project/meta-build.sbt
+++ b/project/meta-build.sbt
@@ -1,0 +1,7 @@
+libraryDependencies ++= Seq(
+  "org.zeroturnaround" % "zt-zip" % "1.12",
+  "org.slf4j" % "slf4j-api" % "1.7.25",
+  "org.slf4j" % "slf4j-nop" % "1.7.25",
+  "com.github.pathikrit" %% "better-files" % "3.5.0",
+  "org.unix4j" % "unix4j-command" % "0.5",
+)


### PR DESCRIPTION
... shamelessly stolen from @mpollmeier. Fixes #15.
Documentation can be generated via
```
sbt generateScalaDocs
```
and ends up in `target/api`.