### PR TITLE
Support for integration tests and sample tests for method stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ project/project
 project/target
 target
 fuzzyc2cpg
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 organization := "io.shiftleft"
 scalaVersion := "2.12.8"
 
-val cpgVersion = "0.9.163"
+val cpgVersion = "0.9.164"
 
 libraryDependencies ++= Seq(
   "io.shiftleft" % "codepropertygraph" % cpgVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 organization := "io.shiftleft"
 scalaVersion := "2.12.8"
 
-val cpgVersion = "0.9.157"
+val cpgVersion = "0.9.163"
 
 libraryDependencies ++= Seq(
   "io.shiftleft" % "codepropertygraph" % cpgVersion,
@@ -10,8 +10,12 @@ libraryDependencies ++= Seq(
   "io.shiftleft" % "enhancements" % cpgVersion,
   "io.shiftleft" % "semanticcpg" % cpgVersion,
   "io.shiftleft" % "dataflowengine" % cpgVersion,
+
+  "io.shiftleft" % "cpgqueryingtests" % cpgVersion % Test,
+  "org.scalatest" %% "scalatest" % "3.0.3" % Test
 )
 
+resolvers += Resolver.mavenLocal
 resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"
 
 enablePlugins(JavaAppPackaging)

--- a/docs/content/querying/_index.md
+++ b/docs/content/querying/_index.md
@@ -12,7 +12,7 @@ One you have [created a code property graph](/docs/creation) stored at
 
 This will run the script in
 ```
-src/main/scala/io/shiftleft/Main.scala
+src/main/scala/io/shiftleft/joern/Main.scala
 ```
 which, by default, queries the CPG for all methods. You can modify this script to run other queries. In the following, we will go through a few examples to get you acquainted with joern.
 
@@ -54,7 +54,7 @@ Method(Some(v[258]),<operator>.assignment,<operator>.assignment,TODO assignment 
 ```
 ### Modifying queries
 
-Next, let's edit `src/main/scala/io/shiftleft/Main.scala` to run different queries,
+Next, let's edit `src/main/scala/io/shiftleft/joern/Main.scala` to run different queries,
 
 You should see the following content before editing:
 ```scala

--- a/src/main/scala/io/shiftleft/joern/Main.scala
+++ b/src/main/scala/io/shiftleft/joern/Main.scala
@@ -1,6 +1,4 @@
-package io.shiftleft
-
-import io.shiftleft.joern.CpgLoader
+package io.shiftleft.joern
 
 object Main extends App {
  val cpg = CpgLoader.load(args(0))

--- a/src/test/scala/io/shiftleft/joern/MethodTests.scala
+++ b/src/test/scala/io/shiftleft/joern/MethodTests.scala
@@ -1,0 +1,36 @@
+package io.shiftleft.joern
+
+import io.shiftleft.cpgqueryingtests.codepropertygraph.{CpgFactory, LanguageFrontend}
+import org.scalatest.{Matchers, WordSpec}
+
+class MethodTests extends WordSpec with Matchers {
+
+  val cpgFactory = new CpgFactory(LanguageFrontend.Fuzzyc, "src/main/resources/default.semantics")
+  val cpg = cpgFactory.buildCpg(
+    """
+      int main(int argc, char **argv) { }
+    """.stripMargin
+  )
+
+  "should return correct function/method name" in {
+    cpg.method.name.toSet shouldBe Set("main")
+  }
+
+  "should return correct number of parameters" in {
+    cpg.parameter.name.toSet shouldBe Set("argc", "argv")
+    cpg.method.name("main").parameter.name.toSet shouldBe Set("argc", "argv")
+  }
+
+  "should return correct parameter types" in {
+    cpg.parameter.name("argc").evalType.l shouldBe List("int")
+    cpg.parameter.name("argv").evalType.l shouldBe List("char * *")
+  }
+
+  "should return correct return type" in {
+    cpg.methodReturn.evalType.l shouldBe List("int")
+    cpg.method.name("main").methodReturn.evalType.l shouldBe List("int")
+    cpg.parameter.name("argc").method.methodReturn.evalType.l shouldBe List("int")
+  }
+
+
+}


### PR DESCRIPTION
On each build, we want to ensure that all queries we showcase in the documentation still work. Furthermore, we want to provide a test-based spec for the query language, making it easy for people to pick up the language. This PR brings in the necessary boilerplate for this and some first tests for method stubs.