### PR TITLE
Add enhancements at generation time (except for data flow)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 organization := "io.shiftleft"
 scalaVersion := "2.12.8"
 
-val cpgVersion = "0.9.174"
+val cpgVersion = "0.9.174+0-038e4965+20190510-2328"
 val fuzzycVersion = "0.1.48"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 organization := "io.shiftleft"
 scalaVersion := "2.12.8"
 
-val cpgVersion = "0.9.174+0-038e4965+20190510-2328"
+val cpgVersion = "0.9.175"
 val fuzzycVersion = "0.1.48"
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -2,7 +2,6 @@ package io.shiftleft.joern
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.layers.EnhancementRunner
-import io.shiftleft.semanticsloader.SemanticsLoader
 
 object Cpg2Scpg {
 
@@ -10,14 +9,11 @@ object Cpg2Scpg {
     * Load the CPG at `cpgFilename` and add enhancements,
     * turning the CPG into an SCPG.
     * @param cpgFilename the filename of the cpg
-    * @param semanticsFilenameOption the filename of the semantics file
     * */
-  def run(cpgFilename: String, semanticsFilenameOption: Option[String] = None): Unit = {
+  def run(cpgFilename: String): Unit = {
     val cpg = CpgLoader.load(cpgFilename)
-    val semanticsFilename = semanticsFilenameOption.getOrElse("src/main/resources/default.semantics")
-    val semantics = new SemanticsLoader(semanticsFilename).load
     val serializedCpg = new SerializedCpg(cpgFilename)
-    new EnhancementRunner(semantics).run(cpg, serializedCpg)
+    new EnhancementRunner().run(cpg, serializedCpg)
     serializedCpg.close
   }
 

--- a/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -1,0 +1,24 @@
+package io.shiftleft.joern
+
+import io.shiftleft.SerializedCpg
+import io.shiftleft.layers.EnhancementRunner
+import io.shiftleft.semanticsloader.SemanticsLoader
+
+object Cpg2Scpg {
+
+  /**
+    * Load the CPG at `cpgFilename` and add enhancements,
+    * turning the CPG into an SCPG.
+    * @param cpgFilename the filename of the cpg
+    * @param semanticsFilenameOption the filename of the semantics file
+    * */
+  def run(cpgFilename: String, semanticsFilenameOption: Option[String] = None): Unit = {
+    val cpg = CpgLoader.load(cpgFilename)
+    val semanticsFilename = semanticsFilenameOption.getOrElse("src/main/resources/default.semantics")
+    val semantics = new SemanticsLoader(semanticsFilename).load
+    val serializedCpg = new SerializedCpg(cpgFilename)
+    new EnhancementRunner(semantics).run(cpg, serializedCpg)
+    serializedCpg.close
+  }
+
+}

--- a/src/main/scala/io/shiftleft/joern/CpgLoader.scala
+++ b/src/main/scala/io/shiftleft/joern/CpgLoader.scala
@@ -1,7 +1,10 @@
 package io.shiftleft.joern
 
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoaderConfig
+import io.shiftleft.layers.DataFlowRunner
+import io.shiftleft.semanticsloader.SemanticsLoader
 
 /**
   * Thin wrapper around `codepropertygraph`'s CpgLoader
@@ -12,9 +15,13 @@ object CpgLoader {
     * Load code property graph
     * @param filename name of the file that stores the cpg
     * */
-  def load(filename: String): Cpg = {
+  def load(filename: String, semanticsFilenameOpt: Option[String] = None): Cpg = {
     val config = CpgLoaderConfig.default
-    io.shiftleft.codepropertygraph.cpgloading.CpgLoader.load(filename, config)
+    val cpg = io.shiftleft.codepropertygraph.cpgloading.CpgLoader.load(filename, config)
+    val semanticsFilename = semanticsFilenameOpt.getOrElse("src/main/resources/default.semantics")
+    val semantics = new SemanticsLoader(semanticsFilename).load
+    new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
+    cpg
   }
 
 }

--- a/src/main/scala/io/shiftleft/joern/CpgLoader.scala
+++ b/src/main/scala/io/shiftleft/joern/CpgLoader.scala
@@ -11,9 +11,8 @@ object CpgLoader {
   /**
     * Load code property graph
     * @param filename name of the file that stores the cpg
-    * @param semanticsFilename file from which semantics are loaded. If not provided defaults are loaded.
     * */
-  def load(filename: String, semanticsFilename: Option[String] = None): Cpg = {
+  def load(filename: String): Cpg = {
     val config = CpgLoaderConfig.default
     io.shiftleft.codepropertygraph.cpgloading.CpgLoader.load(filename, config)
   }

--- a/src/main/scala/io/shiftleft/joern/CpgLoader.scala
+++ b/src/main/scala/io/shiftleft/joern/CpgLoader.scala
@@ -1,10 +1,7 @@
 package io.shiftleft.joern
 
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoaderConfig
-import io.shiftleft.layers.EnhancementRunner
-import io.shiftleft.semanticsloader.SemanticsLoader
 
 /**
   * Thin wrapper around `codepropertygraph`'s CpgLoader
@@ -14,18 +11,11 @@ object CpgLoader {
   /**
     * Load code property graph
     * @param filename name of the file that stores the cpg
-    * @param semanticsFilenameOption file from which semantics are loaded. If not provided defaults are loaded.
+    * @param semanticsFilename file from which semantics are loaded. If not provided defaults are loaded.
     * */
-  def load(filename: String, semanticsFilenameOption: Option[String] = None): Cpg = {
+  def load(filename: String, semanticsFilename: Option[String] = None): Cpg = {
     val config = CpgLoaderConfig.default
-    val cpg = io.shiftleft.codepropertygraph.cpgloading.CpgLoader.load(filename, config)
-
-
-    val semanticsFilename = semanticsFilenameOption.getOrElse("src/main/resources/default.semantics")
-    val semantics = new SemanticsLoader(semanticsFilename).load
-    new EnhancementRunner(semantics).run(cpg, new SerializedCpg())
-
-    cpg
+    io.shiftleft.codepropertygraph.cpgloading.CpgLoader.load(filename, config)
   }
 
 }

--- a/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -1,7 +1,36 @@
 package io.shiftleft.joern
 
-import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
+import io.shiftleft.fuzzyc2cpg.Fuzzyc2Cpg
+import org.slf4j.LoggerFactory
 
 object JoernParse extends App {
-  FuzzyC2Cpg.main(args)
+  val DEFAULT_CPG_OUT_FILE = "cpg.bin.zip"
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  parseConfig.foreach { config =>
+    try {
+      new Fuzzyc2Cpg(config.outputPath).runAndOutput(config.inputPaths.toArray)
+      Cpg2Scpg.run(config.outputPath)
+    } catch {
+      case exception: Exception =>
+        logger.error("Failed to generate CPG.", exception)
+        System.exit(1)
+    }
+    System.exit(0)
+  }
+
+  case class Config(inputPaths: Seq[String], outputPath: String)
+  def parseConfig: Option[Config] =
+    new scopt.OptionParser[Config](getClass.getSimpleName) {
+      arg[String]("<input-dir>")
+        .unbounded()
+        .text("source directories containing C/C++ code")
+        .action((x, c) => c.copy(inputPaths = c.inputPaths :+ x))
+      opt[String]("out")
+        .text("output filename")
+        .action((x, c) => c.copy(outputPath = x))
+
+    }.parse(args, Config(List(), DEFAULT_CPG_OUT_FILE))
+
 }

--- a/src/test/scala/io/shiftleft/joern/DataFlowTests.scala
+++ b/src/test/scala/io/shiftleft/joern/DataFlowTests.scala
@@ -151,7 +151,6 @@ class DataFlowTests extends WordSpec with Matchers {
        |    }
     """.stripMargin
 
-
   val cpg = createTestCpg(code)
 
 }

--- a/src/test/scala/io/shiftleft/joern/LocalsTests.scala
+++ b/src/test/scala/io/shiftleft/joern/LocalsTests.scala
@@ -12,13 +12,11 @@ class LocalsTests extends WordSpec with Matchers {
   }
 
   "should allow to query for all locals in method `free_list`" in {
-    cpg.method.name("free_list")
-      .local.name.toSet shouldBe Set("q", "p")
+    cpg.method.name("free_list").local.name.toSet shouldBe Set("q", "p")
   }
 
   "should prove correct (name, type) pairs for locals" in {
-    cpg.method.name("free_list")
-      .local.map(l => (l.name, l.typeFullName)).toSet shouldBe
+    cpg.method.name("free_list").local.map(l => (l.name, l.typeFullName)).toSet shouldBe
       Set(("q", "struct node *"), ("p", "struct node *"))
   }
 
@@ -52,7 +50,6 @@ class LocalsTests extends WordSpec with Matchers {
        |    return x;
        |    }
     """.stripMargin
-
 
   val cpg = createTestCpg(code)
 

--- a/src/test/scala/io/shiftleft/joern/package.scala
+++ b/src/test/scala/io/shiftleft/joern/package.scala
@@ -3,11 +3,12 @@ package io.shiftleft
 import io.shiftleft.cpgqueryingtests.codepropertygraph.{CpgFactory, LanguageFrontend}
 
 package object joern {
+
   /**
     * Create a CPG for `code` using default semantics
     * @param code string containing C code
     * */
-  def createTestCpg(code : String) = {
+  def createTestCpg(code: String) = {
     val semanticFilename = "src/main/resources/default.semantics"
     new CpgFactory(LanguageFrontend.Fuzzyc, semanticFilename).buildCpg(code)
   }


### PR DESCRIPTION
This is the corresponding `joern` commit for https://github.com/ShiftLeftSecurity/codepropertygraph/pull/165

The idea is to separate enhancements into semantic-dependent and semantic-independent enhancements and execute the semantic-independent enhancements at generation time, while delaying semantic-dependent enhancements to load time. That way, semantic can be changed and the graph can be reloaded for this to take immediate effect - without needing to recalculate all other enhancements.