### PR TITLE
Cleanup shell scripts

### DIFF
--- a/joern-parse
+++ b/joern-parse
@@ -2,7 +2,14 @@
 
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+SCRIPT="$SCRIPT_ABS_DIR/joern-cli/target/universal/stage/bin/joern-parse"
 
 LOG4J_FILENAME="$SCRIPT_ABS_DIR/src/main/resources/log4j2.xml"
 export JAVA_OPTS="-Dlog4j.configurationFile=$LOG4J_FILENAME $JAVA_OPTS"
-$SCRIPT_ABS_DIR/joern-cli/target/universal/stage/bin/joern-parse $@
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "You need to run 'sbt stage' first";
+    exit 1;
+fi;
+
+$SCRIPT $@;

--- a/joern-query
+++ b/joern-query
@@ -2,6 +2,14 @@
 
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+SCRIPT="$SCRIPT_ABS_DIR/joern-cli/target/universal/stage/bin/joern-query"
+
 LOG4J_FILENAME="$SCRIPT_ABS_DIR/src/main/resources/log4j2.xml"
 export JAVA_OPTS="-Dlog4j.configurationFile=$LOG4J_FILENAME $JAVA_OPTS"
-$SCRIPT_ABS_DIR/joern-cli/target/universal/stage/bin/joern-query $@
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "You need to run 'sbt stage' first";
+    exit 1;
+fi;
+
+$SCRIPT $@

--- a/joern-server.sh
+++ b/joern-server.sh
@@ -1,1 +1,0 @@
-./joern-server/target/universal/stage/bin/joern-server

--- a/joernd
+++ b/joernd
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+SCRIPT_ABS_PATH=$(readlink -f "$0")
+SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+SCRIPT="$SCRIPT_ABS_DIR/joern-server/target/universal/stage/bin/joern-server"
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "You need to run 'sbt stage' first";
+    exit 1;
+fi;
+
+$SCRIPT


### PR DESCRIPTION
- Rename `joern-server.sh` to `joernd` to be consistent with naming convention (no .sh extension) and not clash with the directory name `joern-server`
- Ensure that `joernd` works when called from different directories
- Check if code has already been compiled and tell user to run `sbt stage` if not. 