### PR TITLE
Clean exit if port is in use

### DIFF
--- a/joern-server/src/main/scala/io/shiftleft/joern/server/JettyLauncher.scala
+++ b/joern-server/src/main/scala/io/shiftleft/joern/server/JettyLauncher.scala
@@ -4,6 +4,7 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.DefaultServlet
 import org.eclipse.jetty.webapp.WebAppContext
 import org.scalatra.servlet.ScalatraListener
+import org.slf4j.LoggerFactory
 
 /**
   * Launcher to enable running of cpg-server as a
@@ -11,7 +12,9 @@ import org.scalatra.servlet.ScalatraListener
   * */
 object JettyLauncher extends App {
 
-  val port = if (System.getenv("PORT") != null) System.getenv("PORT").toInt else 8080
+  val logger = LoggerFactory.getLogger(getClass)
+
+  val port = if (System.getenv("JOERN_PORT") != null) System.getenv("PORT").toInt else 8080
   val server = new Server(port)
   val context = new WebAppContext()
   context setContextPath "/"
@@ -20,7 +23,16 @@ object JettyLauncher extends App {
   context.addServlet(classOf[DefaultServlet], "/")
 
   server.setHandler(context)
-  server.start
+
+  try {
+    server.start
+  } catch {
+    case exception: java.net.BindException => {
+      logger.warn(s"Not starting server - port $port is occupied")
+      System.exit(1)
+    }
+  }
+
   server.join
 
 }


### PR DESCRIPTION
While testing the client, I often found myself opening up a server when one was already running. Cancelling that with ctrl+c causes delays, so this PR determines whether the port is already in use, and if so, the server is terminated immediately. Also, I renamed the environment variable `PORT` to `JOERN_PORT` to avoid name clashes.