### PR TITLE
Joern CFG to dot script

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernQuery.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernQuery.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.joern
 
-import better.files.File
+import java.io.FileReader
 import javax.script.ScriptEngineManager
 
 object JoernQuery extends App {
@@ -19,10 +19,8 @@ object JoernQuery extends App {
     e.eval(cpgLoadingCode, context)
 
     if (config.isFile) {
-      val reader = File(config.query).fileReader
-      reader.foreach { r =>
-        println(e.eval(r, context))
-      }
+      val reader = new FileReader(config.query)
+      println(e.eval(reader, context))
     } else {
       val script = config.query + ".l.mkString(\"\\n\")"
       println(e.eval(script, context))

--- a/scripts/cfgToDot.scala
+++ b/scripts/cfgToDot.scala
@@ -1,0 +1,37 @@
+import gremlin.scala._
+import io.shiftleft.codepropertygraph.generated._
+import java.nio.file.Paths
+import io.shiftleft.queryprimitives.utils.ExpandTo
+import org.apache.tinkerpop.gremlin.structure.Direction
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
+import javax.script.ScriptEngineManager
+
+
+/** Some helper functions: adapted from ReachingDefPass.scala in codeproperty graph repo */
+def vertexToStr(vertex: Vertex): String = {
+  try {
+    val methodVertex = vertex.vertices(Direction.IN, "AST").nextChecked
+    val fileName = ExpandTo.methodToFile(methodVertex) match {
+      case Some(objFile) => objFile.value2(NodeKeys.NAME)
+      case None          => "NA"
+    }
+
+    s"${Paths.get(fileName).getFileName.toString}: ${vertex.value2(NodeKeys.LINE_NUMBER).toString} ${vertex.value2(NodeKeys.CODE)}"
+  } catch { case _: Exception => "" }
+}
+
+def toDot(graph: ScalaGraph): String = {
+  val buf = new StringBuffer()
+
+  buf.append("digraph g {\n node[shape=plaintext];\n")
+
+  graph.E.hasLabel("CFG").l.foreach { e =>
+    val inV = vertexToStr(e.inVertex).replace("\"", "\'")
+    val outV = vertexToStr(e.outVertex).replace("\"", "\'")
+    buf.append(s""" "$outV" -> "$inV";\n """)
+  }
+  buf.append { "}" }
+  buf.toString
+}
+
+toDot(cpg.graph)


### PR DESCRIPTION
- Script extracts the CFG  of the Code Property Graph and writes it into a dot format:
we might want to generalize this for other edge types or extract only expressions (without identifiers, literals etc.)
 
- Minor change in JoernQuery.scala 