### PR TITLE
Allow running cpg2scpg as a standalone program

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -2,8 +2,33 @@ package io.shiftleft.joern
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.layers.EnhancementRunner
+import org.slf4j.LoggerFactory
 
-object Cpg2Scpg {
+object Cpg2Scpg extends App {
+
+  val DEFAULT_CPG_IN_FILE = "cpg.bin.zip"
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  parseConfig.foreach { config =>
+    try {
+      run(config.inputPath)
+    } catch {
+      case exception: Exception =>
+        logger.error("Failed to generate CPG.", exception)
+        System.exit(1)
+    }
+    System.exit(0)
+  }
+
+  case class Config(inputPath: String)
+  def parseConfig: Option[Config] =
+    new scopt.OptionParser[Config](getClass.getSimpleName) {
+      arg[String]("<cpg>")
+        .text("CPG to enhance")
+        .action((x, c) => c.copy(inputPath = x))
+
+    }.parse(args, Config(DEFAULT_CPG_IN_FILE))
 
   /**
     * Load the CPG at `cpgFilename` and add enhancements,

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -10,7 +10,7 @@ object JoernParse extends App {
 
   parseConfig.foreach { config =>
     try {
-      parse(config.inputPaths.toArray, config.outputPath)
+      parse(config.inputPaths.toArray, config.outputPath, config.enhance)
     } catch {
       case exception: Exception =>
         logger.error("Failed to generate CPG.", exception)
@@ -19,12 +19,14 @@ object JoernParse extends App {
     System.exit(0)
   }
 
-  def parse(inputPaths: Array[String], outputPath: String): Unit = {
+  def parse(inputPaths: Array[String], outputPath: String, enhance : Boolean = true): Unit = {
     new Fuzzyc2Cpg(outputPath).runAndOutput(inputPaths)
-    Cpg2Scpg.run(outputPath)
+    if (enhance){
+      Cpg2Scpg.run(outputPath)
+    }
   }
 
-  case class Config(inputPaths: Seq[String], outputPath: String)
+  case class Config(inputPaths: Seq[String], outputPath: String, enhance : Boolean)
   def parseConfig: Option[Config] =
     new scopt.OptionParser[Config](getClass.getSimpleName) {
       arg[String]("<input-dir>")
@@ -34,7 +36,10 @@ object JoernParse extends App {
       opt[String]("out")
         .text("output filename")
         .action((x, c) => c.copy(outputPath = x))
+      opt[Boolean]("noenhance")
+        .text("run language frontend but do not enhance the CPG to create an SCPG")
+        .action((x,c) => c.copy(enhance = false))
 
-    }.parse(args, Config(List(), DEFAULT_CPG_OUT_FILE))
+    }.parse(args, Config(List(), DEFAULT_CPG_OUT_FILE, true))
 
 }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -13,7 +13,7 @@ object JoernParse extends App {
       parse(config.inputPaths.toArray, config.outputPath, config.enhance)
     } catch {
       case exception: Exception =>
-        logger.error("Failed to generate CPG.", exception)
+        logger.error("Failed to enhance CPG.", exception)
         System.exit(1)
     }
     System.exit(0)

--- a/joern-cpg2scpg
+++ b/joern-cpg2scpg
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+SCRIPT_ABS_PATH=$(readlink -f "$0")
+SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+SCRIPT="$SCRIPT_ABS_DIR/joern-cli/target/universal/stage/bin/cpg-2-scpg"
+
+LOG4J_FILENAME="$SCRIPT_ABS_DIR/joern-cli/src/main/resources/log4j2.xml"
+export JAVA_OPTS="-Dlog4j.configurationFile=$LOG4J_FILENAME $JAVA_OPTS"
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "You need to run 'sbt stage' first";
+    exit 1;
+fi;
+
+$SCRIPT $@;


### PR DESCRIPTION
`joern-parse` currently executes `fuzzyc2cpg`, followed by `cpg2scpg` (enhancements). For performance testing, we want to be able to run `cpg2scpg` as a a standalone program without needing to regenerate the base CPG via `fuzzyc2cpg` every time. This PR makes it possible to run `joern-parse` without enhacements (--noenhance) and `cpg2scpg` as a standalone program.