### PR TITLE
upgrade to latest cpg, includes a fix for the references and a memory leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "joern"
 organization := "io.shiftleft"
 scalaVersion := "2.12.8"
 
-val cpgVersion = "0.9.241"
+val cpgVersion = "0.9.245"
 val fuzzyc2cpgVersion = "0.1.57"
 ThisBuild / resolvers += Resolver.mavenLocal
 ThisBuild / resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"


### PR DESCRIPTION
see https://github.com/ShiftLeftSecurity/codepropertygraph/pull/218