### PR TITLE
Do not apply semantics twice.

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -36,7 +36,7 @@ object Cpg2Scpg extends App {
     * @param cpgFilename the filename of the cpg
     * */
   def run(cpgFilename: String): Unit = {
-    val cpg = CpgLoader.load(cpgFilename)
+    val cpg = CpgLoader.loadWithoutSemantics(cpgFilename)
     val serializedCpg = new SerializedCpg(cpgFilename)
     new EnhancementRunner().run(cpg, serializedCpg)
     serializedCpg.close

--- a/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
@@ -16,12 +16,21 @@ object CpgLoader {
     * @param filename name of the file that stores the cpg
     * */
   def load(filename: String, semanticsFilenameOpt: Option[String] = None): Cpg = {
-    val config = CpgLoaderConfig.default
-    val cpg = io.shiftleft.codepropertygraph.cpgloading.CpgLoader.load(filename, config)
+    val cpg = loadWithoutSemantics(filename)
     val semanticsFilename = semanticsFilenameOpt.getOrElse("joern-cli/src/main/resources/default.semantics")
     val semantics = new SemanticsLoader(semanticsFilename).load
     new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
     cpg
+  }
+
+  /**
+    * Load code property graph but do not apply semantics
+    * @param filename name of the file that stores the cpg
+    * */
+
+  def loadWithoutSemantics(filename : String) : Cpg = {
+    val config = CpgLoaderConfig.default
+    io.shiftleft.codepropertygraph.cpgloading.CpgLoader.load(filename, config)
   }
 
 }


### PR DESCRIPTION
We used to apply semantics every time we loaded the CPG - even before running enhancements in cpg2scpg. That's not necessary, so, we're now not doing that anymore.