### PR TITLE
use G1GC garbage collector: faster, more usable space

### DIFF
--- a/joern-cpg2scpg
+++ b/joern-cpg2scpg
@@ -12,4 +12,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1;
 fi;
 
-$SCRIPT $@;
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m $@;

--- a/joern-parse
+++ b/joern-parse
@@ -12,4 +12,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1;
 fi;
 
-$SCRIPT $@;
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m $@;

--- a/joern-query
+++ b/joern-query
@@ -12,4 +12,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1;
 fi;
 
-$SCRIPT $@
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m $@

--- a/joernd
+++ b/joernd
@@ -10,4 +10,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1;
 fi;
 
-$SCRIPT
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m


### PR DESCRIPTION
1) cpg2sp is 10-20% faster than with other GCs (haven't benchmarked other use cases though)
2) with the same Xmx setting it allows to allocate ~10% more objects (in a very simplistic test, see below)
3) the default GC acts strangely when Xms isn't set at the same time, and the above difference goes up to 20%!

part of https://github.com/ShiftLeftSecurity/product/issues/2681

```
import java.util.ArrayList;
import java.util.List;

public class HeapTests {

  /**
   * -Xmx4g
   * -Xms4g
   * -XX:+UseParallelGC
   * -XX:+UseConcMarkSweepGC
   * -XX:+UseG1GC
   */
  public static void main(String[] args) throws Exception {
    System.out.println("max heap: " + Runtime.getRuntime().maxMemory() / 1024 / 1024);

    List<int[]> data = new ArrayList<>();
    int i = 0;
    try {
      while (true) {
        data.add(new int[1024]);
        i++;
        if (i % 10000 == 0) {
          System.out.println(i);
        }
      }
    } catch (OutOfMemoryError e) {
      System.out.println("max number of elements before OOM: " + i);
    }
  }
}
```