### PR TITLE
Run data flow analysis as part of joern-parse

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -1,6 +1,8 @@
 package io.shiftleft.joern
 
 import io.shiftleft.SerializedCpg
+import io.shiftleft.dataflowengine.layers.dataflows.DataFlowRunner
+import io.shiftleft.dataflowengine.semanticsloader.SemanticsLoader
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
 import org.slf4j.LoggerFactory
 
@@ -12,7 +14,7 @@ object Cpg2Scpg extends App {
 
   parseConfig.foreach { config =>
     try {
-      run(config.inputPath)
+      run(config.inputPath, config.dataFlow, config.semanticsFile)
     } catch {
       case exception: Exception =>
         logger.error("Failed to generate CPG.", exception)
@@ -21,24 +23,34 @@ object Cpg2Scpg extends App {
     System.exit(0)
   }
 
-  case class Config(inputPath: String)
+  case class Config(inputPath: String, dataFlow : Boolean, semanticsFile : String)
   def parseConfig: Option[Config] =
     new scopt.OptionParser[Config](getClass.getSimpleName) {
       arg[String]("<cpg>")
         .text("CPG to enhance")
         .action((x, c) => c.copy(inputPath = x))
+      opt[Unit]("nodataflow")
+        .text("do not perform data flow analysis")
+        .action((x, c) => c.copy(dataFlow = false))
+      opt[String]("semanticsfile")
+        .text("data flow semantics file")
+        .action((x, c) => c.copy(semanticsFile = x))
 
-    }.parse(args, Config(DEFAULT_CPG_IN_FILE))
+    }.parse(args, Config(DEFAULT_CPG_IN_FILE, true, CpgLoader.defaultSemanticsFile))
 
   /**
     * Load the CPG at `cpgFilename` and add enhancements,
     * turning the CPG into an SCPG.
     * @param cpgFilename the filename of the cpg
     * */
-  def run(cpgFilename: String): Unit = {
+  def run(cpgFilename: String, dataFlow : Boolean, semanticsFilename : String): Unit = {
     val cpg = CpgLoader.loadWithoutSemantics(cpgFilename)
     val serializedCpg = new SerializedCpg(cpgFilename)
     new EnhancementRunner().run(cpg, serializedCpg)
+    if (dataFlow) {
+      val semantics = new SemanticsLoader(semanticsFilename).load()
+      new DataFlowRunner(semantics).run(cpg, serializedCpg)
+    }
     serializedCpg.close
   }
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
@@ -21,12 +21,14 @@ object CpgLoader {
     cpg
   }
 
+  val defaultSemanticsFile = "joern-cli/src/main/resources/default.semantics"
+
   /**
     * Apply data flow semantics from `semanticsFilenameOpt` to `cpg`. If `semanticsFilenameOpt`
     * is omitted or None, default semantics will be applied.
     * */
   def applySemantics(cpg : Cpg, semanticsFilenameOpt : Option[String] = None): Unit = {
-    val semanticsFilename = semanticsFilenameOpt.getOrElse("joern-cli/src/main/resources/default.semantics")
+    val semanticsFilename = semanticsFilenameOpt.getOrElse(defaultSemanticsFile)
     val semantics = new SemanticsLoader(semanticsFilename).load
     new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
   }

--- a/joern-cli/src/test/scala/io/shiftleft/joern/GenerationTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/GenerationTests.scala
@@ -21,7 +21,7 @@ class GenerationTests extends WordSpec with Matchers {
     val fuzzyc2Cpg = new FuzzyC2Cpg(outputFilename)
     fuzzyc2Cpg.runAndOutput(inputFilenames)
     // Link CPG fragments and enhance to create semantic CPG
-    Cpg2Scpg.run(outputFilename)
+    Cpg2Scpg.run(outputFilename, false, "")
 
     // Load the CPG
     val cpg = CpgLoader.load(outputFilename)

--- a/joern-server/src/main/scala/io/shiftleft/joern/server/JoernServerImpl.scala
+++ b/joern-server/src/main/scala/io/shiftleft/joern/server/JoernServerImpl.scala
@@ -14,7 +14,7 @@ class JoernServerImpl extends ServerImpl {
   def createCpg(filenames: List[String]): Unit = {
     val cpgFilename = "/tmp/cpg.bin.zip"
     logger.info(s"Attempting to create CPG for: ${filenames.mkString(",")}")
-    JoernParse.parse(filenames.toArray, cpgFilename)
+    JoernParse.parse(filenames.toArray, cpgFilename, true, true, CpgLoader.defaultSemanticsFile)
     cpg = Some(CpgLoader.load(cpgFilename))
     logger.info("CPG is ready")
   }


### PR DESCRIPTION
Usually, people will not want to edit the semantics file. In this case, we should not apply semantics on each load (which can often take longer than the loading operation itself), but rather, we should apply semantics on parsing and store edges as part of `cpg.bin.zip`. This PR introduces this default behavior and allows `joern-parse` and `cpg2scpg` to be configured for deviating behavior.