### PR TITLE
Add missing import to support pipes in `./joern`

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/AmmoniteBridge.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/AmmoniteBridge.scala
@@ -12,6 +12,7 @@ object AmmoniteBridge extends App with BridgeBase {
   override def predefPlus(lines: List[String]): String = {
     val default =
       """
+        |import io.shiftleft.console._
         |import io.shiftleft.joern.console._
         |import io.shiftleft.joern.console.Console._
         |import io.shiftleft.semanticcpg.language._


### PR DESCRIPTION
Forgot an import on launch of the joern shell. This import is necessary for pipe operators to work.