### PR TITLE
Fix wrong path setting 

### DIFF
--- a/joern-parse
+++ b/joern-parse
@@ -2,9 +2,9 @@
 
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
-SCRIPT="$SCRIPT_ABS_DIR/joern-cli/target/universal/stage/bin/joern-parse"
+SCRIPT="joern-cli/target/universal/stage/bin/joern-parse"
 
-LOG4J_FILENAME="$SCRIPT_ABS_DIR/joern-cli/src/main/resources/log4j2.xml"
+LOG4J_FILENAME="joern-cli/src/main/resources/log4j2.xml"
 export JAVA_OPTS="-Dlog4j.configurationFile=$LOG4J_FILENAME $JAVA_OPTS"
 
 if [ ! -f "$SCRIPT" ]; then

--- a/joern-query
+++ b/joern-query
@@ -2,9 +2,9 @@
 
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
-SCRIPT="$SCRIPT_ABS_DIR/joern-cli/target/universal/stage/bin/joern-query"
+SCRIPT="joern-cli/target/universal/stage/bin/joern-query"
 
-LOG4J_FILENAME="$SCRIPT_ABS_DIR/joern-cli/src/main/resources/log4j2.xml"
+LOG4J_FILENAME="joern-cli/src/main/resources/log4j2.xml"
 export JAVA_OPTS="-Dlog4j.configurationFile=$LOG4J_FILENAME $JAVA_OPTS"
 
 if [ ! -f "$SCRIPT" ]; then

--- a/joernd
+++ b/joernd
@@ -2,7 +2,7 @@
 
 SCRIPT_ABS_PATH=$(readlink -f "$0")
 SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
-SCRIPT="$SCRIPT_ABS_DIR/joern-server/target/universal/stage/bin/joern-server"
+SCRIPT="joern-server/target/universal/stage/bin/joern-server"
 
 echo $SCRIPT
 if [ ! -f "$SCRIPT" ]; then


### PR DESCRIPTION
Change `SCRIPT` path setting to fix the issue of unrecognizing the successful `sbt stage` process. Please refer to this issue [#110](https://github.com/ShiftLeftSecurity/joern/issues/110)