### PR TITLE
Add symlinks for `joern(-(parse|query))?`

### DIFF
--- a/joern
+++ b/joern
@@ -1,0 +1,1 @@
+./joern-cli/target/universal/stage/joern

--- a/joern-parse
+++ b/joern-parse
@@ -1,0 +1,1 @@
+./joern-cli/target/universal/stage/joern-parse

--- a/joern-query
+++ b/joern-query
@@ -1,0 +1,1 @@
+./joern-cli/target/universal/stage/joern-query


### PR DESCRIPTION
After running `sbt stage`, executable scripts for joern, joern-parse, and joern-query end up in a target directory, and these are then included in the distribution. For fast turn-around during development, I suggest we introduce these symlinks so that we can already access joern, joern-parse, and joern-query without building the distribution and without tasking us where the build target directory is.