### PR TITLE
Revert "Fix quick start guide."

### DIFF
--- a/docs/content/essentials/quickstart/_index.md
+++ b/docs/content/essentials/quickstart/_index.md
@@ -8,12 +8,7 @@ Clone and build the Joern:
 ```
 git clone https://github.com/ShiftLeftSecurity/joern.git
 cd joern
-sbt createDistribution
-mkdir -p install
-cd install
-unzip ../joern-cli.zip
-unzip ../joern-server.zip
-cd joern-cli
+sbt stage
 ```
 
 Create a cpg (stored in `cpg.bin.zip`):


### PR DESCRIPTION
This reverts commit b3e4b09b1ad167a9ce1a967014dc9ae6d2ebf640.

Since we added symlinks to `joern`, `joern-parse`, and `joern-query`, the quick start guide is accurate again and updating the docs (https://github.com/ShiftLeftSecurity/joern/issues/122) is optional. 