### PR TITLE
Use newest version of fuzzyc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "io.shiftleft"
 ThisBuild/scalaVersion := "2.12.8"
 
 val cpgVersion = "0.10.66"
-val fuzzyc2cpgVersion = "0.1.111"
+val fuzzyc2cpgVersion = "0.1.112"
 
 ThisBuild / resolvers += Resolver.mavenLocal
 ThisBuild / resolvers += "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"


### PR DESCRIPTION
Use newest version of fuzzyC that does not crash when a compilation unit cannot be translated.