### PR TITLE
Add greadlink option for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ Building
 ---
 To create your own distribution of the Joern tools, ensure you have `sbt` installed and simply run 
 `sbt createDistribution`.
+
+For OSX you need to install greadlink package:
+
+```
+brew install coreutils
+```

--- a/joern-cli/src/universal/joern
+++ b/joern-cli/src/universal/joern
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-SCRIPT_ABS_PATH=$(readlink -f "$0")
+if [[ $OSTYPE == darwin* ]]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/ammonite-bridge
 

--- a/joern-cli/src/universal/joern-cpg2scpg
+++ b/joern-cli/src/universal/joern-cpg2scpg
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-SCRIPT_ABS_PATH=$(readlink -f "$0")
+if [[ $OSTYPE == darwin* ]]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/cpg-2-scpg
 

--- a/joern-cli/src/universal/joern-parse
+++ b/joern-cli/src/universal/joern-parse
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-SCRIPT_ABS_PATH=$(readlink -f "$0")
+if [[ $OSTYPE == darwin* ]]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/joern-parse
 

--- a/joern-cli/src/universal/joern-query
+++ b/joern-cli/src/universal/joern-query
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-SCRIPT_ABS_PATH=$(readlink -f "$0")
+if [[ $OSTYPE == darwin* ]]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/joern-query
 

--- a/joern-server/src/universal/joernd
+++ b/joern-server/src/universal/joernd
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-SCRIPT_ABS_PATH=$(readlink -f "$0")
+if [[ $OSTYPE == darwin* ]]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
 SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/joern-server
 


### PR DESCRIPTION
On OSX you couldn't use readlink so have to use greadlink from coreutils package.