### PR TITLE
Refactored the Joern Script Manager

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptExecutor.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptExecutor.scala
@@ -5,13 +5,7 @@ import java.util.UUID
 import cats.data.OptionT
 import cats.effect.{ContextShift, IO}
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.console.query.{
-  CpgOperationFailure,
-  CpgOperationResult,
-  CpgOperationSuccess,
-  CpgQueryExecutor,
-  DefaultCpgQueryExecutor
-}
+import io.shiftleft.console.query.{CpgOperationResult, CpgQueryExecutor, DefaultCpgQueryExecutor}
 import javax.script.ScriptEngineManager
 
 import scala.concurrent.ExecutionContext
@@ -31,14 +25,4 @@ class JoernScriptExecutor extends CpgQueryExecutor[AnyRef] {
   override def retrieveQueryResult(queryId: UUID): OptionT[IO, CpgOperationResult[AnyRef]] =
     ??? // unused within Joern
 
-  def runScript(content: String, cpgFilename: String): AnyRef = {
-    val scriptExecutionResult = for {
-      queryResult <- executeQuerySync(CpgLoader.load(cpgFilename), content)
-      result <- queryResult match {
-        case CpgOperationSuccess(result) => IO(result)
-        case CpgOperationFailure(ex)     => IO.raiseError[AnyRef](ex)
-      }
-    } yield result
-    scriptExecutionResult.handleErrorWith(IO(_)).unsafeRunSync()
-  }
 }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptManager.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptManager.scala
@@ -1,0 +1,30 @@
+package io.shiftleft.joern
+
+import cats.effect.IO
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.console.ScriptManager
+import io.shiftleft.console.query.{CpgOperationFailure, CpgOperationResult, CpgOperationSuccess}
+
+class JoernScriptManager(executor: JoernScriptExecutor = new JoernScriptExecutor()) extends ScriptManager(executor) {
+
+  private def scriptContent(name: String): String =
+    (DEFAULT_SCRIPTS_FOLDER / name / s"$name.scala").lines.mkString(System.lineSeparator())
+
+  private def handleQueryResult(result: IO[CpgOperationResult[AnyRef]]): AnyRef = {
+    val scriptExecutionResult = for {
+      queryResult <- result
+      result <- queryResult match {
+        case CpgOperationSuccess(result) => IO(result)
+        case CpgOperationFailure(ex)     => IO.raiseError[AnyRef](ex)
+      }
+    } yield result
+    scriptExecutionResult.handleErrorWith(IO(_)).unsafeRunSync()
+  }
+
+  def runScript(name: String, cpgFilename: String): AnyRef =
+    handleQueryResult(executor.executeQuerySync(CpgLoader.load(cpgFilename), scriptContent(name)))
+
+  def runScript(name: String, cpg: Cpg): AnyRef =
+    handleQueryResult(executor.executeQuerySync(cpg, scriptContent(name)))
+
+}

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/Console.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/Console.scala
@@ -2,10 +2,9 @@ package io.shiftleft.joern.console
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.console.ScriptManager
-import io.shiftleft.joern.{CpgLoader, JoernScriptExecutor}
+import io.shiftleft.joern.{CpgLoader, JoernScriptManager}
 
-object Console extends ScriptManager(new JoernScriptExecutor()) {
+object Console extends JoernScriptManager {
 
   def banner(): Unit = {
     println("""

--- a/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
@@ -21,17 +21,17 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
     }
   }
 
-  "should execute the list-funcs correctly for example code" in withCpgZip(
-    File(getClass.getClassLoader.getResource("testcode/free"))) { cpg =>
-    val expected = cpg.method.name.l
-    val actual = console.Console.runScript("list-funcs")
-    actual shouldBe expected
-  }
+  "Executing scripts for example code 'testcode/free'" should withCpgZip(
+    File(getClass.getClassLoader.getResource("testcode/free"))) { cpg: Cpg =>
+    "work correctly for 'list-funcs'" in {
+      val expected = cpg.method.name.l
+      val actual = console.Console.runScript("list-funcs", cpg)
+      actual shouldBe expected
+    }
 
-  "should execute the cfgToDot correctly for example code" in withCpgZip(
-    File(getClass.getClassLoader.getResource("testcode/free"))) { _ =>
-    val expected =
-      """digraph g {
+    "work correctly for 'cfgToDot'" in {
+      val expected =
+        """digraph g {
           | node[shape=plaintext];
           | "free.c: 11 p" -> "free.c: 11 free(p)";
           |  "free.c: 11 free(p)" -> "free.c: 9 p";
@@ -52,34 +52,33 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
           |  "free.c: 9 *p = head" -> "free.c: 9 p";
           |  "" -> "free.c: 9 p";
           | }""".stripMargin
-    val actual = console.Console.runScript("cfgToDot")
-    actual shouldBe expected
-  }
+      val actual = console.Console.runScript("cfgToDot", cpg)
+      actual shouldBe expected
+    }
 
-  "should execute the ast-for-funcs correctly for example code" in withCpgZip(
-    File(getClass.getClassLoader.getResource("testcode/free"))) { _ =>
-    val actual = console.Console.runScript("ast-for-funcs").toString
-    actual should include regex """"file" : ".*/testcode/free/free.c""""
-    actual should include(""""function" : "free_list"""")
-    actual should include(""""function" : "free"""")
-    actual should include(""""function" : "<operator>.indirectMemberAccess"""")
-    actual should include(""""function" : "<operator>.assignment"""")
-    actual should include(""""function" : "<operator>.notEquals"""")
-    actual should include("""io.shiftleft.codepropertygraph.generated.edges.Ast""")
-    actual should not include ("""io.shiftleft.codepropertygraph.generated.edges.Cfg""")
-  }
+    "work correctly for 'ast-for-funcs'" in {
+      val actual = console.Console.runScript("ast-for-funcs", cpg).toString
+      actual should include regex """"file" : ".*/testcode/free/free.c""""
+      actual should include(""""function" : "free_list"""")
+      actual should include(""""function" : "free"""")
+      actual should include(""""function" : "<operator>.indirectMemberAccess"""")
+      actual should include(""""function" : "<operator>.assignment"""")
+      actual should include(""""function" : "<operator>.notEquals"""")
+      actual should include("""io.shiftleft.codepropertygraph.generated.edges.Ast""")
+      actual should not include ("""io.shiftleft.codepropertygraph.generated.edges.Cfg""")
+    }
 
-  "should execute the cfg-for-funcs correctly for example code" in withCpgZip(
-    File(getClass.getClassLoader.getResource("testcode/free"))) { _ =>
-    val actual = console.Console.runScript("cfg-for-funcs").toString
-    actual should include regex """"file" : ".*/testcode/free/free.c""""
-    actual should include(""""function" : "free_list"""")
-    actual should include(""""function" : "free"""")
-    actual should include(""""function" : "<operator>.indirectMemberAccess"""")
-    actual should include(""""function" : "<operator>.assignment"""")
-    actual should include(""""function" : "<operator>.notEquals"""")
-    actual should include("""io.shiftleft.codepropertygraph.generated.edges.Cfg""")
-    actual should not include ("""io.shiftleft.codepropertygraph.generated.edges.Ast""")
+    "work correctly for 'cfg-for-funcs'" in {
+      val actual = console.Console.runScript("cfg-for-funcs", cpg).toString
+      actual should include regex """"file" : ".*/testcode/free/free.c""""
+      actual should include(""""function" : "free_list"""")
+      actual should include(""""function" : "free"""")
+      actual should include(""""function" : "<operator>.indirectMemberAccess"""")
+      actual should include(""""function" : "<operator>.assignment"""")
+      actual should include(""""function" : "<operator>.notEquals"""")
+      actual should include("""io.shiftleft.codepropertygraph.generated.edges.Cfg""")
+      actual should not include ("""io.shiftleft.codepropertygraph.generated.edges.Ast""")
+    }
 
   }
 


### PR DESCRIPTION
Running scripts via the Script Manager can now be parameterized with a CPG filename (other than the default one) or a pre-loaded CPG.

As a side effect: this improves performance during testing a lot as CPGs are not loaded/copied multiple times for the same test project anymore. Same holds if a user runs his scripts multiple times with a pre-loaded CPG.