### PR TITLE
Update to newest dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "joern"
 organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.12.8"
 
-val cpgVersion = "0.10.87"
+val cpgVersion = "0.10.94"
 val fuzzyc2cpgVersion = "1.1.4"
 
 ThisBuild / resolvers += Resolver.mavenLocal


### PR DESCRIPTION
I can't download the newest version of `codepropertygraph` yet, although publication to sonatype was successful. With this PR, I am testing whether the artifact can be downloaded when requested from travis. Who knows.