### PR TITLE
Add script to produce DOT for funcs in a CPG

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptExecutor.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptExecutor.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.joern
 
 import java.util.UUID
-
 import cats.data.OptionT
 import cats.effect.{ContextShift, IO}
+
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.console.query.{CpgOperationResult, CpgQueryExecutor, DefaultCpgQueryExecutor}
 import javax.script.ScriptEngineManager
@@ -14,7 +14,27 @@ class JoernScriptExecutor extends CpgQueryExecutor[AnyRef] {
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
-  private val underlying = new DefaultCpgQueryExecutor(new ScriptEngineManager())
+  private lazy val underlying = new DefaultCpgQueryExecutor(new ScriptEngineManager()) {
+    override protected def buildQuery(query: String): String = {
+      s"""
+        |import gremlin.scala._
+        |import io.shiftleft.console._
+        |import io.shiftleft.joern.console._
+        |import io.shiftleft.joern.console.Console._
+        |import io.shiftleft.codepropertygraph.Cpg
+        |import io.shiftleft.codepropertygraph.cpgloading._
+        |import io.shiftleft.codepropertygraph.generated._
+        |import io.shiftleft.codepropertygraph.generated.nodes._
+        |import io.shiftleft.dataflowengine.language._
+        |import io.shiftleft.semanticcpg.language._
+        |import scala.collection.JavaConverters._
+        |implicit val resolver: ICallResolver = NoResolve
+        |val cpg = aCpg.asInstanceOf[io.shiftleft.codepropertygraph.Cpg]
+        |
+        |$query
+        |""".stripMargin
+    }
+  }
 
   override def executeQuery(cpg: Cpg, query: String): IO[UUID] =
     ??? // unused within Joern

--- a/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
@@ -103,6 +103,23 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
       actual should include(""""PDG"""")
     }
 
+    "work correctly for 'functions-to-dot'" in {
+      val actual = console.Console.runScript("functions-to-dot", cpg).asInstanceOf[List[String]]
+      val expected =
+        """|digraph free_list {
+           | node[shape=box];
+           | "11" -> "16" [label="for (struct node *p = head; p != NULL; p = q)"];
+           | "16" -> "18" [label="*p = head"];
+           | "16" -> "22" [label="p != NULL"];
+           | "16" -> "26" [label="p = q"];
+           | "16" -> "30" [label=BLOCK];
+           | "30" -> "31" [label="q = p->next"];
+           | "30" -> "38" [label="free(p)"];
+           |}
+           |""".stripMargin
+
+      actual shouldBe List(expected)
+    }
   }
 
 }

--- a/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
@@ -104,21 +104,21 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
     }
 
     "work correctly for 'functions-to-dot'" in {
-      val actual = console.Console.runScript("functions-to-dot", cpg).asInstanceOf[List[String]]
-      val expected =
-        """|digraph free_list {
-           | node[shape=box];
-           | "11" -> "16" [label="for (struct node *p = head; p != NULL; p = q)"];
-           | "16" -> "18" [label="*p = head"];
-           | "16" -> "22" [label="p != NULL"];
-           | "16" -> "26" [label="p = q"];
-           | "16" -> "30" [label=BLOCK];
-           | "30" -> "31" [label="q = p->next"];
-           | "30" -> "38" [label="free(p)"];
-           |}
+      val List(actual) = console.Console.runScript("functions-to-dot", cpg).asInstanceOf[List[String]]
+
+      val expectedRegex =
+        """|digraph free_list \{
+           | "\d+" -> "\d+" \[label="for \(struct node \*p = head; p != NULL; p = q\)"\];
+           | "\d+" -> "\d+" \[label="\*p = head"\];
+           | "\d+" -> "\d+" \[label="p != NULL"\];
+           | "\d+" -> "\d+" \[label="p = q"\];
+           | "\d+" -> "\d+" \[label=BLOCK\];
+           | "\d+" -> "\d+" \[label="q = p->next"\];
+           | "\d+" -> "\d+" \[label="free\(p\)"\];
+           |\}
            |""".stripMargin
 
-      actual shouldBe List(expected)
+      actual should fullyMatch regex expectedRegex
     }
   }
 

--- a/scripts/functions-to-dot/description.json
+++ b/scripts/functions-to-dot/description.json
@@ -1,4 +1,4 @@
 {
   "name": "functions-to-dot",
-  "description": "Generates a dot graph for each function in the provided CPG. Each file will contain"
+  "description": "Generates a list of strings, each containing a dot graph for every internal function in the provided CPG."
 }

--- a/scripts/functions-to-dot/description.json
+++ b/scripts/functions-to-dot/description.json
@@ -1,0 +1,4 @@
+{
+  "name": "functions-to-dot",
+  "description": "Generates a dot graph for each function in the provided CPG. Each file will contain"
+}

--- a/scripts/functions-to-dot/functions-to-dot.scala
+++ b/scripts/functions-to-dot/functions-to-dot.scala
@@ -63,12 +63,12 @@ def dotFromMethod(method: Method): List[String] = {
 
 def stringifyDotFromMethod(method: Method): String = {
   val sb = new StringBuilder
-  sb.append(s"digraph ${method.name} {\n node[shape=box];\n")
+  sb.append(s"digraph ${method.name} {\n")
   sb.append(dotFromMethod(method).mkString("\n"))
   sb.append("\n}\n")
   sb.toString
 }
 
-cpg.method.filterNot(_.external).l.map { method =>
+cpg.method.internal.l.map { method =>
   stringifyDotFromMethod(method)
 }

--- a/scripts/functions-to-dot/functions-to-dot.scala
+++ b/scripts/functions-to-dot/functions-to-dot.scala
@@ -1,0 +1,74 @@
+/*
+ * Adapted from the `cfgToDot` script to produce a single dot file
+ * per function found in the provided CPG.
+ */
+
+import ammonite.ops._
+import org.apache.tinkerpop.gremlin.structure.{ Direction, Vertex }
+
+import io.shiftleft.codepropertygraph.generated._
+import io.shiftleft.codepropertygraph.generated.nodes.Expression
+import java.nio.file.Paths
+import java.net.URI
+
+import scala.annotation.tailrec
+
+def getTopLevelExpressions(expression: Vertex): List[Expression] = {
+  expression
+    .out(EdgeTypes.AST)
+    .not(_.hasLabel(NodeTypes.LOCAL))
+    .cast[nodes.Expression]
+    .l
+}
+
+def dotFromMethod(method: Method): List[String] = {
+  @tailrec
+  def go(subExprs: List[Expression],
+         parent: Option[Expression] = None,
+         dots: List[String] = List.empty): List[String] = {
+
+    val parentId = parent.map(_.id.toString).getOrElse(method.id)
+
+    subExprs match {
+      case Nil =>
+        dots
+      case expr :: tail => expr match {
+        case ex: Block =>
+          val currDotRepr = s""" "$parentId" -> "${ex.id}" [label=BLOCK];"""
+          go(getTopLevelExpressions(ex) ::: tail, Some(ex), dots :+ currDotRepr)
+        case ex: ControlStructure =>
+          val currDotRepr = s""" "$parentId" -> "${ex.id}" [label="${ex.code}"];"""
+          go(getTopLevelExpressions(ex) ::: tail, Some(ex), dots :+ currDotRepr)
+        case ex: Return =>
+          val currDotRepr =  s""" "$parentId" -> "${ex.id}" [label="${ex.code}"];"""
+          go(tail, parent, dots :+ currDotRepr)
+        case ex: Call =>
+          val currDotRepr = s""" "$parentId" -> "${ex.id}" [label="${ex.code}"];"""
+          go(tail, parent, dots :+ currDotRepr)
+        case ex  => throw new RuntimeException(s"Unhandled node type: [${ex.getClass.getSimpleName}]")
+      }
+    }
+  }
+
+  val methodExpressions = method
+    .out(EdgeTypes.AST)
+    .hasLabel(NodeTypes.BLOCK)
+    .out(EdgeTypes.AST)
+    .not(_.hasLabel(NodeTypes.LOCAL))
+    .cast[nodes.Expression]
+    .l
+
+  go(methodExpressions)
+}
+
+def stringifyDotFromMethod(method: Method): String = {
+  val sb = new StringBuilder
+  sb.append(s"digraph ${method.name} {\n node[shape=box];\n")
+  sb.append(dotFromMethod(method).mkString("\n"))
+  sb.append("\n}\n")
+  sb.toString
+}
+
+cpg.method.filterNot(_.external).l.map { method =>
+  stringifyDotFromMethod(method)
+}


### PR DESCRIPTION
- Adds a new script, `functions-to-dot`, that produces a DOT graph for all internal functions contained within a CPG.