### PR TITLE
Add extension to Cpg for running scripts.

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptManager.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScriptManager.scala
@@ -1,5 +1,19 @@
 package io.shiftleft.joern
 
+import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.console.ScriptManager
 
-class JoernScriptManager(executor: JoernScriptExecutor = new JoernScriptExecutor()) extends ScriptManager(executor)
+class JoernScriptManager(executor: JoernScriptExecutor = new JoernScriptExecutor()) extends ScriptManager(executor) {
+
+  implicit class CpgScriptRunner(cpg: Cpg) {
+
+    /**
+      * Run an arbitrary script over this CPG.
+      *
+      * @param name The name of the script to run.
+      * @return The result of running the script against this CPG.
+      */
+    def runScript(name: String): AnyRef =
+      JoernScriptManager.this.runScript(name, cpg)
+  }
+}


### PR DESCRIPTION
Allows scripts to be run without passing the cpg as a parameter:
```scala
cpg.runScript("script-name")
```