### PR TITLE
Bump CPG version to fix help prompt.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "joern"
 organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.12.8"
 
-val cpgVersion = "0.10.131"
+val cpgVersion = "0.10.138"
 val fuzzyc2cpgVersion = "1.1.13"
 
 ThisBuild / resolvers += Resolver.mavenLocal


### PR DESCRIPTION
Typing `joern --help` now displays the correct help information.