### PR TITLE
Use separate repl directory.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "joern"
 organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.12.8"
 
-val cpgVersion = "0.10.138"
+val cpgVersion = "0.10.139"
 val fuzzyc2cpgVersion = "1.1.13"
 
 ThisBuild / resolvers += Resolver.mavenLocal

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/AmmoniteBridge.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/AmmoniteBridge.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.joern.console
 
-import io.shiftleft.console.BridgeBase
+import io.shiftleft.console.{BridgeBase, JoernProduct}
 
 object AmmoniteBridge extends App with BridgeBase {
 
-  runAmmonite(parseConfig(args))
+  runAmmonite(parseConfig(args), JoernProduct)
 
   /**
     * Code that is executed when starting the shell


### PR DESCRIPTION
- Use `~/.shiftleft/joern` as the REPL directory (previously `~/.shiftleft/ocular`).
- Additional docs changes to match Linux v4.7 (previous based on master).