### PR TITLE
Clarify usage of cpg-create script with joern-server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Joern
 ===
 
 [![Build Status](https://travis-ci.org/ShiftLeftSecurity/joern.svg?branch=master)](https://travis-ci.org/ShiftLeftSecurity/joern)
+[![Gitter](https://badges.gitter.im/joern-code-analyzer/community.svg)](https://gitter.im/joern-code-analyzer/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Documentation on the usage of Joern and Joern server may be found on the Joern [microsite](https://joern.io/docs/).
 

--- a/docs/content/importing/_index.md
+++ b/docs/content/importing/_index.md
@@ -85,3 +85,14 @@ cpg-create tarpit-c
 
 This will parse the code in the directory `tarpit-c`, create a code
 property graph on, and make it available via the joern server.
+
+Note that the directory passed to `cpg-create` **must** be relative to 
+the server's current working directory. For example, with the following setup:
+- `~/joern-server` - server working directory
+- `~/repos/my-code` - code location
+
+We would run `cpg-create`, specifying the location of `my-code` relative to the
+server working directory. This would be:
+```shell script
+ cpg-create ../repos/my-code
+```

--- a/joern-cli/src/universal/joern
+++ b/joern-cli/src/universal/joern
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-if [[ $OSTYPE == darwin* ]]; then
+if [ "$(uname -s)" = "Darwin" ]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
 else
     SCRIPT_ABS_PATH=$(readlink -f "$0")

--- a/joern-cli/src/universal/joern
+++ b/joern-cli/src/universal/joern
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $OSTYPE == darwin* ]]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
@@ -9,8 +9,9 @@ SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/ammonite-bridge
 
 if [ ! -f "$SCRIPT" ]; then
-    echo "Unable to find $SCRIPT, have you created the distribution?";
-    exit 1;
-fi;
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication "$@";
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication "$@"
+

--- a/joern-cli/src/universal/joern-cpg2scpg
+++ b/joern-cli/src/universal/joern-cpg2scpg
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-if [[ $OSTYPE == darwin* ]]; then
+if [ "$(uname -s)" = "Darwin" ]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
 else
     SCRIPT_ABS_PATH=$(readlink -f "$0")

--- a/joern-cli/src/universal/joern-cpg2scpg
+++ b/joern-cli/src/universal/joern-cpg2scpg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $OSTYPE == darwin* ]]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
@@ -9,8 +9,8 @@ SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/cpg-2-scpg
 
 if [ ! -f "$SCRIPT" ]; then
-    echo "Unable to find $SCRIPT, have you created the distribution?";
-    exit 1;
-fi;
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@";
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@"

--- a/joern-cli/src/universal/joern-parse
+++ b/joern-cli/src/universal/joern-parse
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-if [[ $OSTYPE == darwin* ]]; then
+if [ "$(uname -s)" = "Darwin" ]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
 else
     SCRIPT_ABS_PATH=$(readlink -f "$0")

--- a/joern-cli/src/universal/joern-parse
+++ b/joern-cli/src/universal/joern-parse
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $OSTYPE == darwin* ]]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
@@ -9,8 +9,8 @@ SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
 SCRIPT="$SCRIPT_ABS_DIR"/bin/joern-parse
 
 if [ ! -f "$SCRIPT" ]; then
-    echo "Unable to find $SCRIPT, have you created the distribution?";
-    exit 1;
-fi;
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@";
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@"

--- a/joern-server/src/universal/joernd
+++ b/joern-server/src/universal/joernd
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-if [[ $OSTYPE == darwin* ]]; then
+if [ "$(uname -s)" = "Darwin" ]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
 else
     SCRIPT_ABS_PATH=$(readlink -f "$0")

--- a/joern-server/src/universal/joernd
+++ b/joern-server/src/universal/joernd
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [[ $OSTYPE == darwin* ]]; then
     SCRIPT_ABS_PATH=$(greadlink -f "$0")
@@ -15,3 +15,4 @@ if [ ! -f "$SCRIPT" ]; then
 fi;
 
 $SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@"
+


### PR DESCRIPTION
- Fix minor issue with launcher scripts using `sh` even though the scripts contain bash extensions. The scripts now run with `bash` rather than `sh`.