### PR TITLE
Add new PDG script.

### DIFF
--- a/joern-cli/src/main/resources/scripts/general/pdg-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/general/pdg-for-funcs-dump.sc
@@ -70,7 +70,6 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import org.apache.tinkerpop.gremlin.structure.{Edge, VertexProperty}
 
-import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.dataflowengine.language._
 import io.shiftleft.joern.console.Console.cpg

--- a/joern-cli/src/main/resources/scripts/general/pdg.sc
+++ b/joern-cli/src/main/resources/scripts/general/pdg.sc
@@ -1,0 +1,33 @@
+/* pdg.sc
+
+   This script returns a complete PDG for the whole CPG, seperate into two lists, once for the edges and another for the
+   vertices.
+
+   The first list contains all of the edges in the PDG. The first entry in each tuple contains the ID of the incoming
+   vertex. The second entry in the tuple contains the ID of the outgoing vertex.
+
+   The second list contains all the vertices in the PDG. The first entry in each tuple contains the ID of the vertex
+   and the second entry contains the code stored in the vertex.
+*/
+
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.joern.console.Console.cpg
+
+import scala.collection.mutable
+
+type EdgeEntry = (AnyRef, AnyRef)
+type VertexEntry = (AnyRef, String)
+
+val edges = cpg.scalaGraph.E().filter(edge => edge.hasLabel(EdgeTypes.REACHING_DEF, EdgeTypes.CDG)).dedup.l
+
+val (edgeResult, vertexResult) =
+  edges.foldLeft((mutable.Set.empty[EdgeEntry], mutable.Set.empty[VertexEntry])) {
+    case ((edgeList, vertexList), edge) =>
+      val edgeEntry = (edge.inVertex().id, edge.outVertex().id)
+      val inVertexEntry = (edge.inVertex().id, edge.inVertex().property("CODE").orElse(""))
+      val outVertexEntry = (edge.inVertex().id, edge.inVertex().property("CODE").orElse(""))
+
+      (edgeList += edgeEntry, vertexList ++= Set(inVertexEntry, outVertexEntry))
+  }
+
+(edgeResult.toList, vertexResult.toList)

--- a/joern-cli/src/main/resources/scripts/general/pdg.sc
+++ b/joern-cli/src/main/resources/scripts/general/pdg.sc
@@ -1,6 +1,6 @@
 /* pdg.sc
 
-   This script returns a complete PDG for the whole CPG, seperate into two lists, once for the edges and another for the
+   This script returns a complete PDG for the whole CPG, separated into two lists, once for the edges and another for the
    vertices.
 
    The first list contains all of the edges in the PDG. The first entry in each tuple contains the ID of the incoming

--- a/joern-cli/src/main/resources/scripts/general/scripts.json
+++ b/joern-cli/src/main/resources/scripts/general/scripts.json
@@ -34,6 +34,10 @@
       "description": "Lists all functions."
     },
     {
+      "name": "pdg",
+      "description": "Generate a PDG for the whole CPG."
+    },
+    {
       "name": "pdg-for-funcs-dump",
       "description": "Prints the corresponding PDG for each function as Json string to a file."
     }

--- a/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
@@ -78,15 +78,12 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
       actual should not include """io.shiftleft.codepropertygraph.generated.edges.Ast"""
     }
 
-    "work correctly for 'pdg-for-funcs'" ignore {
-      val actual = console.Console.runScript("general/pdg-for-funcs", cpg).toString
-      actual should include(""""function" : "free_list"""")
-      actual should include(""""function" : "free"""")
-      actual should include(""""function" : "<operator>.indirectMemberAccess"""")
-      actual should include(""""function" : "<operator>.assignment"""")
-      actual should include(""""function" : "<operator>.notEquals"""")
-      actual should include("""io.shiftleft.codepropertygraph.generated.edges.Ast""")
-      actual should include("""io.shiftleft.codepropertygraph.generated.edges.Cfg""")
+    "work correctly for 'pdg'" in {
+      val actual = console.Console.runScript("general/pdg", cpg).toString
+
+      val expectedRegex = """\(List\((\(\d+,\d+\),?\s?)+\),List\((\(\d+,[\w\W]+\),?\s?)+\)\)""".r
+
+      actual should fullyMatch regex expectedRegex
     }
 
     "work correctly for 'graph-for-funcs'" in {


### PR DESCRIPTION
For the following program:
```c
int main() {  
  int a = 2;
  int b = 3;  if (a > 0) print(a);
  int result = foo(a, b);
  return result;  
}

int foo(int x, int y) {
  return x + y;
}

void print(int x) {
  printf(x);  
}
```

This script will print:
```
res2: AnyRef = (
  List(
    (57L, 54L),
    (26L, 20L),
    (24L, 20L),
    (31L, 10L),
    (31L, 15L),
    (24L, 10L),
    (35L, 28L),
    (28L, 31L),
    (46L, 42L),
    (43L, 45L),
    (46L, 41L),
    (7L, 35L),
    (20L, 10L)
  ),
  List(
    (35L, "return result;"),
    (28L, "result = foo(a, b)"),
    (24L, "print(a)"),
    (20L, "a > 0"),
    (7L, "RET"),
    (31L, "foo(a, b)"),
    (46L, "x + y"),
    (57L, "printf(x)"),
    (43L, "RET"),
    (26L, "a")
  )
)
```

The first list contains the edges between the vertices `in_vertex_id => out_vertex_id`. The second contains all of the vertices in the PDG, along with the code that the vertex contains.