### PR TITLE
Add description for using fuzzyc2cpg cpgs

### DIFF
--- a/docs/content/importing/_index.md
+++ b/docs/content/importing/_index.md
@@ -110,4 +110,4 @@ Cpg2Scpg.run("cpg.bin.zip", true, CpgLoader.defaultSemanticsFile)
 loadCpg("cpg.bin.zip")
 ```
 
-Beware: This is not the intended way to do things. Normally you should be alright using `joern-parse`.
+Beware: This is not the intended way to do things! Normally you should be alright using `joern-parse`.

--- a/docs/content/importing/_index.md
+++ b/docs/content/importing/_index.md
@@ -106,7 +106,8 @@ One can trigger the enhancement step manually by doing the following in the REPL
 ```scala
 import io.shiftleft.joern.Cpg2Scpg
 import io.shiftleft.joern.CpgLoader
-Cpg2Scpg.run("cpg.bin.zip", true, CpgLoader.defaultSemanticsFile)  
+Cpg2Scpg.run("cpg.bin.zip", true, CpgLoader.defaultSemanticsFile)
+loadCpg("cpg.bin.zip")
 ```
 
 Beware: This is not the intended way to do things. Normally you should be alright using `joern-parse`.

--- a/docs/content/importing/_index.md
+++ b/docs/content/importing/_index.md
@@ -96,3 +96,17 @@ server working directory. This would be:
 ```shell script
  cpg-create ../repos/my-code
 ```
+
+## Creating Code Property Graphs with self built [fuzzyc2cpg](https://github.com/ShiftLeftSecurity/fuzzyc2cpg)
+
+When using the fuzzyc language frontend directly (instead of running `joern-parse`) the cpg file that is created does not include enhancements. These enhancements are needed to find external methods, not declared in the input source code for example. When using `joern-parse` these enhancements are written into the created cpg file.
+
+One can trigger the enhancement step manually by doing the following in the REPL:
+
+```scala
+import io.shiftleft.joern.Cpg2Scpg
+import io.shiftleft.joern.CpgLoader
+Cpg2Scpg.run("cpg.bin.zip", true, CpgLoader.defaultSemanticsFile)  
+```
+
+Beware: This is not the intended way to do things. Normally you should be alright using `joern-parse`.


### PR DESCRIPTION
We had problems finding methods in cpgs that were built with fuzzy2cpg. This explains why we had those problems and provides a solution. 
@fabsx00 Do we actually want to put this information in the official docs? This place seems the most logical to search for this info, that's why I put it here.