### PR TITLE
bump dependencies, adjust test expectations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ organization := "io.shiftleft"
  * to 2.13.2 once that's released */
 ThisBuild / scalaVersion := "2.13.0"
 
-val cpgVersion = "0.11.15"
-val fuzzyc2cpgVersion = "1.1.19"
+val cpgVersion = "0.11.40"
+val fuzzyc2cpgVersion = "1.1.25"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
@@ -60,7 +60,7 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
       val actual = console.Console.runScript("general/ast-for-funcs.sc", Map.empty, cpg).toString
       actual should include(""""function" : "free_list"""")
       actual should include(""""function" : "free"""")
-      actual should include(""""function" : "<operator>.indirectMemberAccess"""")
+      actual should include(""""function" : "<operator>.indirectFieldAccess"""")
       actual should include(""""function" : "<operator>.assignment"""")
       actual should include(""""function" : "<operator>.notEquals"""")
       actual should include("""io.shiftleft.codepropertygraph.generated.edges.Ast""")
@@ -71,7 +71,7 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
       val actual = console.Console.runScript("general/cfg-for-funcs.sc", Map.empty, cpg).toString
       actual should include(""""function" : "free_list"""")
       actual should include(""""function" : "free"""")
-      actual should include(""""function" : "<operator>.indirectMemberAccess"""")
+      actual should include(""""function" : "<operator>.indirectFieldAccess"""")
       actual should include(""""function" : "<operator>.assignment"""")
       actual should include(""""function" : "<operator>.notEquals"""")
       actual should include("""io.shiftleft.codepropertygraph.generated.edges.Cfg""")
@@ -90,7 +90,7 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
       val actual = console.Console.runScript("general/graph-for-funcs.sc", Map.empty, cpg).toString
       actual should include(""""function" : "free_list"""")
       actual should include(""""function" : "free"""")
-      actual should include(""""function" : "<operator>.indirectMemberAccess"""")
+      actual should include(""""function" : "<operator>.indirectFieldAccess"""")
       actual should include(""""function" : "<operator>.assignment"""")
       actual should include(""""function" : "<operator>.notEquals"""")
       actual should include("""io.shiftleft.codepropertygraph.generated.edges.Ast""")


### PR DESCRIPTION
Recent updates in fuzzyc2cpg and codepropertygraph caused failing builds. This bumps versions to incorporate the bugfixes, and adapts test expectations to the new reality.