### PR TITLE
Add script to detect assignment to member of const object.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ organization := "io.shiftleft"
  * to 2.13.2 once that's released */
 ThisBuild / scalaVersion := "2.13.0"
 
-val cpgVersion = "0.11.47"
-val fuzzyc2cpgVersion = "1.1.26"
+val cpgVersion = "0.11.53"
+val fuzzyc2cpgVersion = "1.1.27"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/joern-cli/src/main/resources/scripts/c/const-ish.sc
+++ b/joern-cli/src/main/resources/scripts/c/const-ish.sc
@@ -1,0 +1,16 @@
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.{Member, Method}
+import io.shiftleft.dataflowengine.language._
+import io.shiftleft.semanticcpg.language._
+
+@main def main(): Set[Method] = {
+  (cpg: Cpg).method
+    .internal
+    .whereNonEmpty { method =>
+
+    method.start
+      .assignments
+      .target
+      .reachableBy(method.parameter.where(_.typeFullName.contains("const")))
+  }.toSet
+}

--- a/joern-cli/src/main/resources/scripts/c/scripts.json
+++ b/joern-cli/src/main/resources/scripts/c/scripts.json
@@ -6,6 +6,10 @@
       "description": "Lists all functions that may potentially be marked as const functions."
     },
     {
+      "name": "const-ish.sc",
+      "description": "Detect assignment to const parameters or members of const parameters."
+    },
+    {
       "name": "malloc-leak.sc",
       "description": "Lists all malloc calls that do not have a corresponding free."
     },

--- a/joern-cli/src/test/resources/testcode/const-ish/const-ish.c
+++ b/joern-cli/src/test/resources/testcode/const-ish/const-ish.c
@@ -1,0 +1,92 @@
+void modify_non_const_struct(struct Foo* foo) {
+  foo = NULL;
+  return;
+}
+
+void modify_const_struct(const struct Foo* foo) {
+  foo = NULL;
+  return;
+}
+
+void modify_const_struct_c_cast(const struct Foo* foo) {
+  struct Foo* foo2 = (Foo*) foo;
+  foo2 = NULL;
+  return;
+}
+
+void modify_const_struct_cpp_cast(const struct Foo* foo) {
+  struct Foo* foo2 = const_cast<Foo*>(foo);
+  foo2 = NULL;
+  return;
+}
+
+void modify_non_const_struct_member(struct Foo* foo) {
+  foo->y = 5;
+  return;
+}
+
+void modify_const_struct_member(const struct Foo* foo) {
+  foo->y = 5;
+  return;
+}
+
+void modify_const_struct_member_c_cast(const struct Foo* foo) {
+  struct Foo* foo2 = (Foo*) foo;
+  foo2->y = 5;
+  return;
+}
+
+void modify_const_struct_member_cpp_cast(const struct Foo* foo) {
+  struct Foo* foo2 = const_cast<Foo*>(foo);
+  foo2->y = 5;
+  return;
+}
+
+class Oop {
+  Foo* fooA;
+  const Foo* fooB;
+
+  void non_const_member() {
+    fooA = NULL;
+    return;
+  }
+
+  void const_member() {
+    fooB = NULL;
+    return;
+  }
+
+  void const_member_c_cast() {
+    Foo* f = (Foo*) this->fooB;
+    f = NULL;
+    return;
+  }
+
+  void const_member_cpp_cast() {
+    Foo* f = const_cast<Foo*>(this->fooB);
+    f = NULL;
+    return;
+  }
+
+  void non_const_member_update() {
+    fooA->y = 7;
+    return;
+  }
+
+  void const_member_update() {
+    fooB->y = 7;
+    return;
+  }
+
+  void const_c_cast_member_update() {
+    Foo* f = (Foo*) this->fooB;
+    f->y = 7;
+    return;
+  }
+
+  void const_cpp_cast_member_update() {
+    Foo* f = const_cast<Foo*>(this->fooB);
+    f->y = 7;
+    return;
+  }
+};

--- a/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/RunScriptTests.scala
@@ -104,6 +104,25 @@ class RunScriptTests extends WordSpec with Matchers with AbstractJoernCliTest {
     }
   }
 
+  "Executing scripts for example code 'testcode/const-ish" should withCpgZip(
+    File(getClass.getClassLoader.getResource("testcode/const-ish"))) { cpg: Cpg =>
+    "work correctly for 'const-ish.sc'" in {
+      val methods =
+        console.Console.runScript("c/const-ish.sc", Map.empty, cpg).asInstanceOf[Set[Method]]
+
+      // "side_effect_number" is included here as we are simply trying to emulate a side effect.
+      methods.map(_.name) should contain theSameElementsAs
+        Set(
+          "modify_const_struct_member_cpp_cast",
+          "modify_const_struct_member_c_cast",
+          "modify_const_struct_member",
+          "modify_const_struct_cpp_cast",
+          "modify_const_struct_c_cast",
+          "modify_const_struct"
+        )
+    }
+  }
+
   "Executing scripts for example code 'testcode/free'" should withCpgZip(
     File(getClass.getClassLoader.getResource("testcode/free"))) { cpg: Cpg =>
     "work correctly for 'list-funcs'" in {


### PR DESCRIPTION
This supports the detection of modifying a member of a const object directly, or via casting it to a non-const type and then modifying.

I attempted to add support for detecting assignment to const class members but the `Member` node isn't a `TrackingPoint` so I was unable to find any flows for these. If there is a way do let me know and I'll re-add it!