### PR TITLE
Use FuzzyC2Cpg's overflowdb mode by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 
 val cpgVersion = "0.11.76"
-val fuzzyc2cpgVersion = "1.1.28"
+val fuzzyc2cpgVersion = "1.1.32"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.joern
 
-import better.files.File
 import io.shiftleft.dataflowengine.layers.dataflows.DataFlowRunner
 import io.shiftleft.dataflowengine.semanticsloader.SemanticsLoader
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
 import io.shiftleft.SerializedCpg
+import io.shiftleft.codepropertygraph.Cpg
 import org.slf4j.LoggerFactory
 
 object Cpg2Scpg extends App {
@@ -15,7 +15,7 @@ object Cpg2Scpg extends App {
 
   parseConfig.foreach { config =>
     try {
-      run(config.inputPath, "store.bin", config.dataFlow, config.semanticsFile)
+      run(config.inputPath, config.dataFlow, config.semanticsFile).close()
     } catch {
       case exception: Exception =>
         logger.error("Failed to generate CPG.", exception)
@@ -40,21 +40,19 @@ object Cpg2Scpg extends App {
     }.parse(args, Config(DEFAULT_CPG_IN_FILE, true, CpgLoader.defaultSemanticsFile))
 
   /**
-    * Load the CPG at `cpgFilename` and add enhancements,
+    * Load the CPG at `storeFilename` and add enhancements,
     * turning the CPG into an SCPG.
     * @param storeFilename the filename of the cpg
     * */
-  def run(inputFilename: String, storeFilename: String, dataFlow: Boolean, semanticsFilename: String): Unit = {
-    val storeFile = File(storeFilename)
-    if (storeFilename != "" && storeFile.exists) { storeFile.delete() }
-    val cpg = CpgLoader.load(inputFilename, storeFilename)
+  def run(storeFilename: String, dataFlow: Boolean, semanticsFilename: String): Cpg = {
+    val cpg = CpgLoader.loadFromOdb(storeFilename)
     new EnhancementRunner().run(cpg, new SerializedCpg())
     if (dataFlow) {
       val semantics = new SemanticsLoader(semanticsFilename).load()
       new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
     }
     io.shiftleft.codepropertygraph.cpgloading.CpgLoader.createIndexes(cpg)
-    cpg.graph.close()
+    cpg
   }
 
 }

--- a/joern-cli/src/test/scala/io/shiftleft/joern/AbstractJoernCliTest.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/AbstractJoernCliTest.scala
@@ -1,8 +1,11 @@
 package io.shiftleft.joern
 
+import java.util.concurrent.LinkedBlockingQueue
+
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
+import io.shiftleft.proto.cpg.Cpg.CpgStruct
 
 trait AbstractJoernCliTest {
 
@@ -12,22 +15,18 @@ trait AbstractJoernCliTest {
 
   private def loadTestCpg(file: File): (Cpg, String) = {
     val inputFilenames = Set(file.pathAsString)
-    val tmpFile = File.newTemporaryFile("cpg", "bin.zip")
+    val tmpFile = File.newTemporaryFile("cpg", "bin")
     val fuzzycOutFilename = tmpFile.pathAsString
     tmpFile.delete()
 
     // Create a CPG using the C/C++ fuzzy parser
-    val fuzzyc2Cpg = new FuzzyC2Cpg(fuzzycOutFilename)
+    val queue = new LinkedBlockingQueue[CpgStruct.Builder]()
+    val factory = new io.shiftleft.fuzzyc2cpg.output.overflowdb.OutputModuleFactory(fuzzycOutFilename, queue)
+    val fuzzyc2Cpg = new FuzzyC2Cpg(factory)
     fuzzyc2Cpg.runAndOutput(inputFilenames, Set(".c"))
     // Link CPG fragments and enhance to create semantic CPG
-
-    val storeTmpFile = File.newTemporaryFile("store", "bin")
-    val storeFilename = storeTmpFile.pathAsString
-    storeTmpFile.delete()
-    Cpg2Scpg.run(fuzzycOutFilename, storeFilename, dataFlow = true, CpgLoader.defaultSemanticsFile)
-
-    // Load the CPG
-    (CpgLoader.loadFromOdb(storeFilename), fuzzycOutFilename)
+    val cpg = Cpg2Scpg.run(fuzzycOutFilename, dataFlow = true, CpgLoader.defaultSemanticsFile)
+    (cpg, fuzzycOutFilename)
   }
 
 }


### PR DESCRIPTION
Re: https://github.com/ShiftLeftSecurity/fuzzyc2cpg/pull/182
Use FuzzyC2Cpg's overflowDB output mode. The entire CPG creation thus now uses lazy-loading.