### PR TITLE
Create indices only once

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -51,7 +51,6 @@ object Cpg2Scpg extends App {
       val semantics = new SemanticsLoader(semanticsFilename).load()
       new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
     }
-    io.shiftleft.codepropertygraph.cpgloading.CpgLoader.createIndexes(cpg)
     cpg
   }
 


### PR DESCRIPTION
We are already creating indices when shutting down the OverflowDbWriter of `FuzzyC2Cpg`, we do not need to create the index again.