### PR TITLE
Update `cpg` dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "io.shiftleft"
  * to 2.13.2 once that's released */
 ThisBuild / scalaVersion := "2.13.0"
 
-val cpgVersion = "0.11.83"
+val cpgVersion = "0.11.87"
 val fuzzyc2cpgVersion = "1.1.32"
 
 ThisBuild / resolvers ++= Seq(

--- a/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
+++ b/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
@@ -1,7 +1,7 @@
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.language._
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.Assignment
+import io.shiftleft.semanticcpg.language.operatorextension.opnodes.Assignment
 
 private def mallocCalls(cpg: Cpg): Steps[Assignment] = {
   cpg.assignment.where { assignment =>

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -15,7 +15,12 @@ object Cpg2Scpg extends App {
 
   parseConfig.foreach { config =>
     try {
-      run(config.inputPath, config.dataFlow, config.semanticsFile).close()
+      val cpg = run(config.inputPath, config.dataFlow, config.semanticsFile)
+      logger.info(s"Closing Cpg...")
+      val startTime = System.currentTimeMillis()
+      cpg.close()
+      logger.info(s"Done in : ${System.currentTimeMillis() - startTime} ms")
+
     } catch {
       case exception: Exception =>
         logger.error("Failed to generate CPG.", exception)
@@ -51,7 +56,6 @@ object Cpg2Scpg extends App {
       val semantics = new SemanticsLoader(semanticsFilename).load()
       new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
     }
-    io.shiftleft.codepropertygraph.cpgloading.CpgLoader.createIndexes(cpg)
     cpg
   }
 


### PR DESCRIPTION
In addition, log time it takes to close the CPG and remove redundant call to `createIndex`.