### PR TITLE
Run fuzzyc and enhancements in separate JVMs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ organization := "io.shiftleft"
  * to 2.13.2 once that's released */
 ThisBuild / scalaVersion := "2.13.0"
 
-val cpgVersion = "0.11.87"
+val cpgVersion = "0.11.90"
 val fuzzyc2cpgVersion = "1.1.32"
 
 ThisBuild / resolvers ++= Seq(

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -24,21 +24,23 @@ object JoernParse extends App {
 
   def generateCpg(config: ParserConfig): Unit = {
 
-    val queue = new LinkedBlockingQueue[CpgStruct.Builder]()
-    val factory = new io.shiftleft.fuzzyc2cpg.output.overflowdb.OutputModuleFactory(config.outputCpgFile, queue)
-    val fuzzyc = new FuzzyC2Cpg(factory)
-    if (config.preprocessorConfig.usePreprocessor) {
-      fuzzyc.runWithPreprocessorAndOutput(
-        config.inputPaths,
-        config.sourceFileExtensions,
-        config.preprocessorConfig.includeFiles,
-        config.preprocessorConfig.includePaths,
-        config.preprocessorConfig.defines,
-        config.preprocessorConfig.undefines,
-        config.preprocessorConfig.preprocessorExecutable
-      )
-    } else {
-      fuzzyc.runAndOutput(config.inputPaths, config.sourceFileExtensions)
+    if (!config.enhanceOnly) {
+      val queue = new LinkedBlockingQueue[CpgStruct.Builder]()
+      val factory = new io.shiftleft.fuzzyc2cpg.output.overflowdb.OutputModuleFactory(config.outputCpgFile, queue)
+      val fuzzyc = new FuzzyC2Cpg(factory)
+      if (config.preprocessorConfig.usePreprocessor) {
+        fuzzyc.runWithPreprocessorAndOutput(
+          config.inputPaths,
+          config.sourceFileExtensions,
+          config.preprocessorConfig.includeFiles,
+          config.preprocessorConfig.includePaths,
+          config.preprocessorConfig.defines,
+          config.preprocessorConfig.undefines,
+          config.preprocessorConfig.preprocessorExecutable
+        )
+      } else {
+        fuzzyc.runAndOutput(config.inputPaths, config.sourceFileExtensions)
+      }
     }
 
     if (config.enhance) {
@@ -51,6 +53,7 @@ object JoernParse extends App {
                           outputCpgFile: String = DEFAULT_CPG_OUT_FILE,
                           enhance: Boolean = true,
                           dataFlow: Boolean = true,
+                          enhanceOnly: Boolean = false,
                           semanticsFile: String = CpgLoader.defaultSemanticsFile,
                           sourceFileExtensions: Set[String] = Set(".c", ".cc", ".cpp", ".h", ".hpp"),
                           preprocessorConfig: PreprocessorConfig = PreprocessorConfig())
@@ -78,6 +81,9 @@ object JoernParse extends App {
       opt[Unit]("noenhance")
         .text("run language frontend but do not enhance the CPG to create an SCPG")
         .action((x, c) => c.copy(enhance = false))
+      opt[Unit]("enhanceonly")
+        .text("Only run the enhancer")
+        .action((x, c) => c.copy(enhanceOnly = true))
       opt[Unit]("nodataflow")
         .text("do not perform data flow analysis")
         .action((x, c) => c.copy(dataFlow = false))

--- a/joern-cli/src/universal/joern-parse
+++ b/joern-cli/src/universal/joern-parse
@@ -13,4 +13,5 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@"
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@" --noenhance
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@" --enhanceonly


### PR DESCRIPTION
To create an overflowdb for all Linux Kernel 5.5 drivers, with `-Xmx30G` on `Intel(R) Core(TM) i9-7900X CPU @ 3.30GHz`, we are now at approximately 1 hour. This includes running all passes, in particular intra-procedural reachability analysis, `CDG` edges, and `CONTAINS` edges.

I have been running tests on creating overflowdb files for all drivers of the Linux kernel, and it turned out that `joern-parse` ran into GC trouble while `./joern-parse --noenhance`, followed by `./joern-cpg2scpg` did not. In other words, although all memory allocated as part of `fuzzyc` could be freed, it is not, possibly due to a memory leak. To circumvent this problem and similar problems in the future, we now spin up `joern-cpg2scp` in a separate JVM.