### PR TITLE
Reduce duplication for predefs

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/Predefined.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Predefined.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.joern
+
+object Predefined {
+
+  /* ammonite tab completion is partly broken for scala > 2.12.8
+   * applying workaround for package wildcard imports from https://github.com/lihaoyi/Ammonite/issues/1009 */
+  val shared: String = """
+        |import gremlin.scala.{`package` => _, _}
+        |import io.shiftleft.console.{`package` => _, _}
+        |import io.shiftleft.joern.console._
+        |import io.shiftleft.codepropertygraph.Cpg
+        |import io.shiftleft.codepropertygraph.cpgloading._
+        |import io.shiftleft.codepropertygraph.generated._
+        |import io.shiftleft.codepropertygraph.generated.nodes._
+        |import io.shiftleft.codepropertygraph.generated.edges._
+        |import io.shiftleft.dataflowengine.language.{`package` => _, _}
+        |import io.shiftleft.semanticcpg.language.{`package` => _, _}
+        |import scala.jdk.CollectionConverters._
+        |implicit val resolver: ICallResolver = NoResolve
+        |
+      """.stripMargin
+
+  val forInteractiveShell: String = shared +
+    """
+      | import io.shiftleft.joern.console.Console._
+    """.stripMargin
+
+  val forScripts: String = shared +
+    """
+    | import io.shiftleft.joern.console.Console.{cpg => _, _}
+  """.stripMargin
+
+}

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/AmmoniteBridge.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/AmmoniteBridge.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.joern.console
 
 import io.shiftleft.console.{BridgeBase, JoernProduct}
+import io.shiftleft.joern.Predefined
 
 object AmmoniteBridge extends App with BridgeBase {
 
@@ -10,26 +11,8 @@ object AmmoniteBridge extends App with BridgeBase {
     * Code that is executed when starting the shell
     * */
   override def predefPlus(lines: List[String]): String = {
-    /* ammonite tab completion is partly broken for scala > 2.12.8
-     * applying workaround for package wildcard imports from https://github.com/lihaoyi/Ammonite/issues/1009 */
-    val default =
-      """
-        |import gremlin.scala.{`package` => _, _}
-        |import io.shiftleft.console.{`package` => _, _}
-        |import io.shiftleft.joern.console._
-        |import io.shiftleft.joern.console.Console._
-        |import io.shiftleft.codepropertygraph.Cpg
-        |import io.shiftleft.codepropertygraph.cpgloading._
-        |import io.shiftleft.codepropertygraph.generated._
-        |import io.shiftleft.codepropertygraph.generated.nodes._
-        |import io.shiftleft.codepropertygraph.generated.edges._
-        |import io.shiftleft.dataflowengine.language.{`package` => _, _}
-        |import io.shiftleft.semanticcpg.language.{`package` => _, _}
-        |import scala.jdk.CollectionConverters._
-        |implicit val resolver: ICallResolver = NoResolve
-        |
-      """.stripMargin
-    lines.foldLeft(default) { case (res, line) => res + s"\n$line" }
+
+    lines.foldLeft(Predefined.forInteractiveShell) { case (res, line) => res + s"\n$line" }
   }
 
   override def promptStr(): String = "joern> "

--- a/joern-cli/src/main/scala/io/shiftleft/joern/scripting/JoernAmmoniteExecutor.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/scripting/JoernAmmoniteExecutor.scala
@@ -1,22 +1,9 @@
 package io.shiftleft.joern.scripting
 
 import io.shiftleft.console.scripting.AmmoniteExecutor
+import io.shiftleft.joern.Predefined
 
 object JoernAmmoniteExecutor extends AmmoniteExecutor {
   override lazy val predef: String =
-    """
-      |import gremlin.scala.{`package` => _, _}
-      |import io.shiftleft.console.{`package` => _, _}
-      |import io.shiftleft.joern.console._
-      |import io.shiftleft.joern.console.Console.{cpg => _, _}
-      |import io.shiftleft.codepropertygraph.Cpg
-      |import io.shiftleft.codepropertygraph.cpgloading._
-      |import io.shiftleft.codepropertygraph.generated._
-      |import io.shiftleft.codepropertygraph.generated.nodes._
-      |import io.shiftleft.codepropertygraph.generated.edges._
-      |import io.shiftleft.dataflowengine.language.{`package` => _, _}
-      |import io.shiftleft.semanticcpg.language.{`package` => _, _}
-      |import scala.jdk.CollectionConverters._
-      |implicit val resolver: ICallResolver = NoResolve
-      |""".stripMargin
+    Predefined.forScripts
 }


### PR DESCRIPTION
We were using slightly different predefs for ammonite for the interactive shell vs scripts. To reduce duplication and make the difference immediately visible, I've introduced a `Predef` object hosting shared code and the diffs.