### PR TITLE
Support installation via script on macOS

### DIFF
--- a/joern-install.sh
+++ b/joern-install.sh
@@ -4,9 +4,9 @@ set -eu
 if [ "$(uname)" = 'Darwin' ]; then
   # get script location
   # https://unix.stackexchange.com/a/96238
-  if [ -n "$BASH_SOURCE" ]; then
+  if [ "${BASH_SOURCE:-x}" != 'x' ]; then
     this_script=$BASH_SOURCE
-  elif [ -n "$ZSH_VERSION" ]; then
+  elif [ "${ZSH_VERSION:-x}" != 'x' ]; then
     setopt function_argzero
     this_script=$0
   elif eval '[[ -n ${.sh.file} ]]' 2>/dev/null; then

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -1,8 +1,26 @@
 #!/usr/bin/env sh
 set -eu
 
-SCRIPT_ABS_PATH=$(readlink -f "$0")
-SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
+if [ "$(uname)" = 'Darwin' ]; then
+  # get script location
+  # https://unix.stackexchange.com/a/96238
+  if [ -n "$BASH_SOURCE" ]; then
+    this_script=$BASH_SOURCE
+  elif [ -n "$ZSH_VERSION" ]; then
+    setopt function_argzero
+    this_script=$0
+  elif eval '[[ -n ${.sh.file} ]]' 2>/dev/null; then
+    eval 'this_script=${.sh.file}'
+  else
+    echo 1>&2 "Unsupported shell. Please use bash, ksh93 or zsh."
+    exit 2
+  fi
+  relative_directory=$(dirname "$this_script")
+  SCRIPT_ABS_DIR=$(cd "$relative_directory" && pwd)
+else
+  SCRIPT_ABS_PATH=$(readlink -f "$0")
+  SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
+fi
 
 # Check required tools are installed.
 check_installed() {


### PR DESCRIPTION
The `readlink` command on macOS does not support the `-f` / `--canonicalize`
parameter available in the GNU version. This adds a check for the Darwin
kernel and provides an alternative approach to finding the script's
directory.

Addresses: #229