### PR TITLE
Fix pager + tell people about `help`

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion,
   "io.shiftleft" %% "dataflowengine" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpgVersion,
+  "com.lihaoyi" %%  "ammonite"              % "2.0.4"      cross CrossVersion.full,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.github.scopt" %% "scopt" % "3.7.1",
   "com.github.pathikrit" %% "better-files" % "3.8.0",

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernConsole.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernConsole.scala
@@ -27,7 +27,11 @@ class JoernConsole extends Console[Project](JoernAmmoniteExecutor, new JoernWork
         |╚█████╔╝╚██████╔╝███████╗██║  ██║██║ ╚████║
         | ╚════╝  ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝
       """.stripMargin)
+    println(helpMsg())
   }
+
+  private def helpMsg(): String =
+    s"""Type `help` or `browse(help)` to begin""".stripMargin
 
   // If you remove this, the shell will not start.
   def version(): String = {


### PR DESCRIPTION
* For some reason, the pager doesn't work if ammonite is not specified as a direct dependency in joern
* Print a little message to point people to `help` and `browse(help)`
