### PR TITLE
Make it possible to run fuzzyc directly

### DIFF
--- a/fuzzyc2cpg.sh
+++ b/fuzzyc2cpg.sh
@@ -1,0 +1,1 @@
+./joern-cli/target/universal/stage/fuzzyc2cpg.sh

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Fuzzyc2cpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Fuzzyc2cpg.scala
@@ -1,0 +1,7 @@
+package io.shiftleft.joern
+
+import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
+
+object Fuzzyc2cpg extends App {
+  FuzzyC2Cpg.main(args)
+}

--- a/joern-cli/src/universal/fuzzyc2cpg.sh
+++ b/joern-cli/src/universal/fuzzyc2cpg.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
+SCRIPT="$SCRIPT_ABS_DIR"/bin/fuzzyc-2-cpg
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m "$@"


### PR DESCRIPTION
Fuzzyc2cpg needs to be runnable directly from the joern install directory for `importCode` to work.