### PR TITLE
Fix passing of semantics to OssDataFlow pass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "0.11.203"
+val cpgVersion = "0.11.208+0-78426bcf+20200514-1437"
 val fuzzyc2cpgVersion = "1.1.37"
 
 ThisBuild / resolvers ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "0.11.208+0-78426bcf+20200514-1437"
+val cpgVersion = "0.11.209"
 val fuzzyc2cpgVersion = "1.1.37"
 
 ThisBuild / resolvers ++= Seq(

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -54,9 +54,8 @@ object Cpg2Scpg extends App {
     val context = new LayerCreatorContext(cpg, new SerializedCpg())
     new Scpg().run(context)
     if (dataFlow) {
-      val semantics = new SemanticsLoader(semanticsFilename).load()
-      val options = new OssDataFlowOptions(semantics)
-      new OssDataFlow().run(context, Some(options))
+      val options = new OssDataFlowOptions(semanticsFilename)
+      new OssDataFlow(() => options).run(context)
     }
     cpg
   }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
@@ -4,7 +4,6 @@ import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoaderConfig
 import io.shiftleft.dataflowengine.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
-import io.shiftleft.dataflowengine.semanticsloader.SemanticsLoader
 import java.nio.file.{FileSystems, Files, Paths}
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
@@ -40,10 +39,9 @@ object CpgLoader {
     if (semanticsFilenameOpt.isDefined) {
       removeAllSemantics(cpg)
       val semanticsFilename = semanticsFilenameOpt.getOrElse(defaultSemanticsFile)
-      val semantics = new SemanticsLoader(semanticsFilename).load
       val context = new LayerCreatorContext(cpg, new SerializedCpg())
-      val options = new OssDataFlowOptions(semantics)
-      new OssDataFlow().run(context, Some(options))
+      val options = new OssDataFlowOptions(semanticsFilename)
+      new OssDataFlow(() => options).run(context)
     }
   }
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernAmmoniteExecutor.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernAmmoniteExecutor.scala
@@ -3,6 +3,7 @@ package io.shiftleft.joern.console
 import io.shiftleft.console.scripting.AmmoniteExecutor
 
 object JoernAmmoniteExecutor extends AmmoniteExecutor {
+
   override lazy val predef: String =
     Predefined.forScripts
 }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
@@ -20,6 +20,7 @@ object Predefined {
         |import scala.jdk.CollectionConverters._
         |implicit val resolver: ICallResolver = NoResolve
         |
+        |
       """.stripMargin
 
   val forInteractiveShell: String = shared +
@@ -36,7 +37,8 @@ object Predefined {
 
   def dynamicPredef(): String = {
     Run.codeForRunCommand() +
-      Help.codeForHelpCommand[io.shiftleft.joern.console.JoernConsole]
+      Help.codeForHelpCommand[io.shiftleft.joern.console.JoernConsole] +
+      "\nopts.ossdataflow.semanticsFilename = io.shiftleft.joern.CpgLoader.defaultSemanticsFile\n"
   }
 
 }


### PR DESCRIPTION
- Adaptions to changes in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/738
- Also, make `run.ossdataflow` work by default