### PR TITLE
wildcard import from staged `lib` dir

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -27,6 +27,7 @@ excludeDependencies ++= Seq(
 )
 
 enablePlugins(JavaAppPackaging)
+scriptClasspath := Seq("*") //wildcard import from staged `lib` dir, for simplicity and also to avoid `line too long` error on windows
 
 topLevelDirectory := Some(packageName.value)
 


### PR DESCRIPTION
for simplicity and also to avoid `line too long` error on windows