### PR TITLE
Make sure `joern` script picks up log4j2.xml

### DIFF
--- a/joern-cli/src/universal/joern
+++ b/joern-cli/src/universal/joern
@@ -13,5 +13,5 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -J-XX:+UseStringDeduplication "$@"
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml -J-XX:+UseStringDeduplication "$@"
 


### PR DESCRIPTION
Slight regression: while joern-parse uses the correct logger config, joern does not.