### PR TITLE
Tune down default logger config

### DIFF
--- a/joern-cli/src/universal/conf/log4j2.xml
+++ b/joern-cli/src/universal/conf/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} %p %c{0}: %msg%n"/>
@@ -9,9 +9,9 @@
         <Logger name="org.apache.tomcat" level="error"/>
         <Logger name="org.apache.jasper" level="error"/>
         <Logger name="org.reflections" level="off" />
-        <Logger name="io.shiftleft.overflowdb" level="debug" />
+        <Logger name="io.shiftleft.overflowdb" level="warn" />
 
-        <Root level="INFO">
+        <Root level="WARN">
             <AppenderRef ref="Console" />
         </Root>
     </Loggers>


### PR DESCRIPTION
Ran Joern a bit with the default logger config and while the info printed is relevant for devs, it's quite noisy for users. Tuned down the log level to WARN again.