### PR TITLE
Make github happy

### DIFF
--- a/html/packages/website/gatsby-config.js
+++ b/html/packages/website/gatsby-config.js
@@ -12,8 +12,8 @@ module.exports = {
         name: 'shiftleft-joern-website',
         short_name: 'website',
         start_url: '/',
-        background_color: '#663399',
-        theme_color: '#663399',
+        background_color: '#000000',
+        theme_color: '#000000',
         display: 'minimal-ui',
         icon: 'src/assets/images/website-icon.png', // This path is relative to the root of the site.
       },

--- a/html/packages/website/package-lock.json
+++ b/html/packages/website/package-lock.json
@@ -2295,7 +2295,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -6551,7 +6551,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "0.2.1",
           "bundled": true,
           "dev": true,
           "optional": true


### PR DESCRIPTION
Github seems to now include checking of context-less checking of dependencies for versions that are known to contain vulnerabilities of some sort. Upgraded versions to make it happy again. Also replaced gatsby default theme color.