### PR TITLE
Update CPGQL terminology

### DIFF
--- a/docs2/docs/cpgql/augmentation-directives.mdx
+++ b/docs2/docs/cpgql/augmentation-directives.mdx
@@ -3,7 +3,7 @@ id: augmentation-directives
 title: Augmentation Directives
 ---
 
-Augmentation Directives are CPGQL Components that allow you to extend a Code Property Graph with nodes, property, and edges.
+Augmentation Directives are CPGQL Directives which extend a Code Property Graph with nodes, properties and edges.
 
 Take the following simple program named `X42`:
 

--- a/docs2/docs/cpgql/complex-steps.mdx
+++ b/docs2/docs/cpgql/complex-steps.mdx
@@ -3,7 +3,7 @@ id: complex-steps
 title: Complex Steps
 ---
 
-_Complex Steps_ are steps which are made of combinations of basic steps. They can be of three types, _Generic Complex Steps_, _Call Graph Steps_ or _Dataflow Complex Steps_.
+Complex Steps are CPGQL Steps which combine the functionality of one or more Node-Type Steps, Repeat Steps, Filter Steps, Core Steps or Execution Directives. They are represented by one or more Directives and can be of three types: _Generic Complex Steps_, _Call Graph Steps_ or _Dataflow Complex Steps_.
 
 
 ## Generic Complex Steps

--- a/docs2/docs/cpgql/core-steps.mdx
+++ b/docs2/docs/cpgql/core-steps.mdx
@@ -3,7 +3,7 @@ id: core-steps
 title: Core Steps
 ---
 
-_Core Steps_ are CPGQL Steps which can be combined with any other Step.
+Core Steps are CPGQL Steps which can be combined with any other Step.
 Joern offers four _Core Steps_, `map`, `sideEffect`, `dedup` and `clone`.
 
 We will look at each one while analyzing a simple program named `X42`:

--- a/docs2/docs/cpgql/execution-directives.mdx
+++ b/docs2/docs/cpgql/execution-directives.mdx
@@ -3,7 +3,7 @@ id: execution-directives
 title: Execution Directives
 ---
 
-_Execution Directives_ are CPGQL Components which execute the queries they suffix and return the results of the execution in a specific format. The most straightforward _Execution Directive_ is `toList` which, as the name suggests, executes the CPGQL Query it suffixes and returns the results in a list:
+Execution Directives are CPGQL Directives which execute the traversals they suffix and return the result in a specific format. The most straightforward _Execution Directive_ is `toList` which, as the name suggests, executes the CPGQL Query it suffixes and returns the results in a list:
 
 ### toList
 

--- a/docs2/docs/cpgql/filter-steps.mdx
+++ b/docs2/docs/cpgql/filter-steps.mdx
@@ -3,7 +3,7 @@ id: filter-steps
 title: Filter Steps
 ---
 
-Joern supports four _Generic Filter Steps_ which can be added to any other step, and number of specific filter steps called _Property Filter Steps_ which can be used on nodes of a certain type.
+Filter Steps are CPGQL Steps which filter nodes in a traversal according to a criterion. Joern supports four _Generic Filter Steps_ which can be added to any other step, and number of specific filter steps called _Property Filter Steps_ which can be used on nodes of a certain type.
 The _Generic Filter Steps_ are  `where`, `whereNonEmpty`, `filter` and `filterNot`. The _Property Filter Steps_ for each node type correspond to the _Property Directives_ it has defined.
 
 We will look at the behaviour of each of these steps while analyzing a simple program named `X42`:

--- a/docs2/docs/cpgql/help-directive.mdx
+++ b/docs2/docs/cpgql/help-directive.mdx
@@ -3,8 +3,7 @@ id: help-directive
 title: Help Directive
 ---
 
-The _Help Directive_ is a CPGQL Component which returns textual descriptions of other CPGQL Components.
-
+The Help Directive is a CPGQL Directive which returns textual descriptions of other directives.
 
 If it is executed by itself, it shows an overview of [Top-Level Commands](/joern/top-level-commands):
 

--- a/docs2/docs/cpgql/node-type-steps.mdx
+++ b/docs2/docs/cpgql/node-type-steps.mdx
@@ -8,6 +8,8 @@ import NodeStepDetail from '@site/src/components/NodeStepDetail';
 
 import { cpgqlRef, StepKind, StepFamily } from '@site/src/cpgqlref';
 
+Node-Type Steps are CPGQL Steps that traverse nodes based on their type.
+
 ### Overview
 
 <NodeStepsOverviewTable stepsInfo={cpgqlRef.stepsInfoForFamily(StepFamily.NodeTypeStep)} />

--- a/docs2/docs/cpgql/repeat-steps.mdx
+++ b/docs2/docs/cpgql/repeat-steps.mdx
@@ -3,7 +3,7 @@ id: repeat-steps
 title: Repeat Steps
 ---
 
-_Repeat Steps_ are steps which repeat a traversal a number of times.
+Repeat Steps are CPGQL Steps which repeat another traversal multiple times.
 
 ### repeat..times
 


### PR DESCRIPTION
Some of the wording used to describe various CPGQL steps was inconsistent and also not flexible enough to describe dataflow steps. This change in terminology fixes those two issues by making the `Directive` a basic building block for definitions in CPGQL.

```
> OVERVIEW

>>> Directive
CPGQL Directives are keywords of the Code Property Graph Query Language.

>>> Step
CPGQL Steps are combinations of one or more Directives that describe graph traversals in the CPGQL. They are represented by one or more Directives.

>>> Node-Type Step
CPGQL Node-Type Steps are Steps that traverse nodes based on their type. They are represented by a single Directive.

>>> Filter Step
CPGQL Filter Steps are Steps which filter nodes in a traversal according to a criterion. They are represented by one or more Directives.

>>> Repeat Step
CPGQL Repeat Steps are Steps which repeat another traversal multiple times. They are represented by one or more Directives.

>>> Complex Step
CPGQL Complex Steps are Step which combine the functionality of one or more Node-Type Step, Repeat Step, Filter Step, Core Step or Execution Directive. They are represented by one or more Directives.

>>> Core Step
CPGQL Core Steps are Steps which can be combined with any other Step. They are represented by one or more Directives.

>>> Execution Directive
CPGQL Execution Directives are Directives which suffix Steps and execute the traversal the Steps represent.

>>> Augmentation Directive
CPGQL Augmentation Directives are Directives which extend a Code Property Graph with nodes, properties and edges.

>>> Help Directive
The CPGQL Help Directive is a Directive which returns textual descriptions of other directives.

>>> Entry Directive
A CPGQL Entry Directive is a Directive which references the entry node of a Code Property Graph.

>>> Query
A CPGQL Query is a combination of more than two Directives.
```