### PR TITLE
Adapt to changes in `codepropertygraph`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "0.11.398"
+val cpgVersion = "0.11.400"
 val fuzzyc2cpgVersion = "1.1.73"
 
 ThisBuild / resolvers ++= Seq(

--- a/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/CpgLoader.scala
@@ -26,7 +26,7 @@ object CpgLoader {
   }
 
   /**
-    * Load code property graph from overflowDB and apply semantics
+    * Load code property graph from overflowDB
     * @param filename name of the file that stores the cpg
     * */
   def loadFromOdb(filename: String): Cpg = {

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernProject.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernProject.scala
@@ -4,10 +4,11 @@ import java.nio.file.Path
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.console.workspacehandling.{Project, ProjectFile}
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 
 class JoernProject(projectFile: ProjectFile,
                    path: Path,
                    cpg: Option[Cpg] = None,
-                   var semantics: Semantics = Semantics.empty)
+                   var context: EngineContext = EngineContext(Semantics.empty))
     extends Project(projectFile, path, cpg) {}


### PR DESCRIPTION
We now need to hand in an EngineContext as opposed to semantics.