### PR TITLE
use odb traversal instead of tinkerpop api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,9 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "0.11.403"
-val fuzzyc2cpgVersion = "1.1.73"
+
+val cpgVersion = "0.12.2"
+val fuzzyc2cpgVersion = "1.1.75"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-
 val cpgVersion = "0.12.2"
 val fuzzyc2cpgVersion = "1.1.75"
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "0.12.2"
-val fuzzyc2cpgVersion = "1.1.75"
+val cpgVersion = "0.12.1"
+val fuzzyc2cpgVersion = "1.1.79"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/joern-cli/src/main/resources/scripts/c/const-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/c/const-funcs.sc
@@ -3,6 +3,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension._
 import io.shiftleft.dataflowengineoss.language._
+import overflowdb.traversal._
 
 private def callOutsAreConst(method: Method): Boolean = {
   method.start.callOut.calledMethod.internal.l.forall(_.signature.contains("const"))
@@ -16,7 +17,7 @@ private def parameterOpsAreConst(method: Method): Boolean = {
 }
 
 @main def main(): Set[Method] = {
-  (cpg: Cpg).method.internal.where { method =>
+  cpg.method.internal.filter { method =>
     !method.signature.contains("const") &&
       callOutsAreConst(method) &&
       parameterOpsAreConst(method)

--- a/joern-cli/src/main/resources/scripts/c/const-ish.sc
+++ b/joern-cli/src/main/resources/scripts/c/const-ish.sc
@@ -2,14 +2,17 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Member, Method}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
 
 @main def main(): Set[Method] = {
   cpg.method
     .internal
-    .whereNot { method =>
+    .filter { method =>
       method
+        .start
         .assignments
         .target
         .reachableBy(method.parameter.filter(_.typeFullName.contains("const")))
+        .nonEmpty
   }.toSet
 }

--- a/joern-cli/src/main/resources/scripts/c/const-ish.sc
+++ b/joern-cli/src/main/resources/scripts/c/const-ish.sc
@@ -4,13 +4,12 @@ import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
 
 @main def main(): Set[Method] = {
-  (cpg: Cpg).method
+  cpg.method
     .internal
-    .whereNonEmpty { method =>
-
-    method.start
-      .assignments
-      .target
-      .reachableBy(method.parameter.where(_.typeFullName.contains("const")))
+    .whereNot { method =>
+      method
+        .assignments
+        .target
+        .reachableBy(method.parameter.filter(_.typeFullName.contains("const")))
   }.toSet
 }

--- a/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
+++ b/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
@@ -2,10 +2,11 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.opnodes.Assignment
+import overflowdb.traversal._
 
 @main def main() = {
-  val allocated = cpg.call("malloc").inAssignment.target.toSet
-  val freed = cpg.call("free").argument(1).l
-  val flowsFromAllocToFree = freed.start.reachableBy(allocated.start).toSet
+  def allocated = cpg.call("malloc").inAssignment.target.dedup
+  def freed = cpg.call("free").argument(1)
+  def flowsFromAllocToFree = freed.reachableBy(allocated).toSet
   allocated.map(_.code).toSet.diff(flowsFromAllocToFree.map(_.code))
 }

--- a/joern-cli/src/main/resources/scripts/c/malloc-overflow.sc
+++ b/joern-cli/src/main/resources/scripts/c/malloc-overflow.sc
@@ -2,11 +2,12 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
 
 @main def main(): List[Call] = {
-  (cpg: Cpg)
+  cpg
     .call("malloc")
-    .where { mallocCall =>
+    .filter { mallocCall =>
       mallocCall.argument(1) match {
         case subCall: Call =>
           subCall.name == Operators.addition || subCall.name == Operators.multiplication

--- a/joern-cli/src/main/resources/scripts/c/pointer-to-int.sc
+++ b/joern-cli/src/main/resources/scripts/c/pointer-to-int.sc
@@ -3,6 +3,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, FieldId
 import io.shiftleft.codepropertygraph.generated.{Operators, nodes}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension._
+import overflowdb.traversal._
 
 private def expressionIsPointer(argument: Expression, isSubExpression: Boolean = false): Boolean = {
   argument match {
@@ -18,9 +19,9 @@ private def expressionIsPointer(argument: Expression, isSubExpression: Boolean =
 }
 
 @main def main(): List[nodes.Call] = {
-  (cpg: Cpg).assignment
-    .where(assign => assign.source.isInstanceOf[Call] && assign.target.isInstanceOf[Identifier])
-    .where { assignment =>
+  cpg.assignment
+    .filter(assign => assign.source.isInstanceOf[Call] && assign.target.isInstanceOf[Identifier])
+    .filter { assignment =>
       val target = assignment.target.asInstanceOf[Identifier]
       val source = assignment.source.asInstanceOf[Call]
 

--- a/joern-cli/src/main/resources/scripts/c/syscalls.sc
+++ b/joern-cli/src/main/resources/scripts/c/syscalls.sc
@@ -410,6 +410,6 @@ private val linuxSyscalls: Set[String] = Set(
 )
 
 @main def main(): List[Call] = {
-  (cpg: Cpg).call.where(c => linuxSyscalls.contains(c.name)).l
+  cpg.call.filter(c => linuxSyscalls.contains(c.name)).l
 }
 

--- a/joern-cli/src/main/resources/scripts/c/userspace-memory-access.sc
+++ b/joern-cli/src/main/resources/scripts/c/userspace-memory-access.sc
@@ -16,5 +16,5 @@ private val calls: Set[String] = Set(
 )
 
 @main def main(): List[Call] = {
-  (cpg: Cpg).call.where(call => calls.contains(call.name)).l
+  cpg.call.filter(call => calls.contains(call.name)).l
 }

--- a/joern-cli/src/main/resources/scripts/graph/ast-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/graph/ast-for-funcs-dump.sc
@@ -89,8 +89,8 @@ final case class AstForFuncsFunction(function: String, id: String, AST: List[Ast
 
 implicit val encodeFuncFunction: Encoder[AstForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[OdbEdge] =
-  (edge: OdbEdge) =>
+implicit val encodeEdge: Encoder[Edge] =
+  (edge: Edge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/ast-for-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/graph/ast-for-funcs.sc
@@ -88,8 +88,8 @@ final case class AstForFuncsResult(functions: List[AstForFuncsFunction])
 implicit val encodeFuncResult: Encoder[AstForFuncsResult] = deriveEncoder
 implicit val encodeFuncFunction: Encoder[AstForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[OdbEdge] =
-  (edge: OdbEdge) =>
+implicit val encodeEdge: Encoder[Edge] =
+  (edge: Edge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs-dump.sc
@@ -86,8 +86,8 @@ final case class CfgForFuncsFunction(function: String, id: String, CFG: List[nod
 
 implicit val encodeFuncFunction: Encoder[CfgForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[OdbEdge] =
-  (edge: OdbEdge) =>
+implicit val encodeEdge: Encoder[Edge] =
+  (edge: Edge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs.sc
@@ -87,8 +87,8 @@ final case class CfgForFuncsResult(functions: List[CfgForFuncsFunction])
 implicit val encodeFuncResult: Encoder[CfgForFuncsResult] = deriveEncoder
 implicit val encodeFuncFunction: Encoder[CfgForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[OdbEdge] =
-  (edge: OdbEdge) =>
+implicit val encodeEdge: Encoder[Edge] =
+  (edge: Edge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/cfgToDot.sc
+++ b/joern-cli/src/main/resources/scripts/graph/cfgToDot.sc
@@ -50,11 +50,11 @@ def vertexToStr(vertex: Node): String = {
       case _ => "NA"
     }
 
-    s"${Paths.get(fileName).getFileName.toString}: ${vertex.property(NodeKeysOdb.LINE_NUMBER)} ${vertex.property(NodeKeysOdb.CODE)}"
+    s"${Paths.get(fileName).getFileName.toString}: ${vertex.property(NodeKeys.LINE_NUMBER)} ${vertex.property(NodeKeys.CODE)}"
   } catch { case _: Exception => "" }
 }
 
-def toDot(graph: OdbGraph): String = {
+def toDot(graph: Graph): String = {
   val buf = new StringBuffer()
 
   buf.append("digraph g {\n node[shape=plaintext];\n")

--- a/joern-cli/src/main/resources/scripts/graph/functions-to-dot.sc
+++ b/joern-cli/src/main/resources/scripts/graph/functions-to-dot.sc
@@ -5,12 +5,8 @@
 
 import ammonite.ops._
 
-import io.shiftleft.codepropertygraph.generated._
-import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import java.nio.file.Paths
 import java.net.URI
-import overflowdb._
-import overflowdb.traversal._
 import scala.annotation.tailrec
 
 def getTopLevelExpressions(expression: Node): List[Expression] = {

--- a/joern-cli/src/main/resources/scripts/graph/functions-to-dot.sc
+++ b/joern-cli/src/main/resources/scripts/graph/functions-to-dot.sc
@@ -53,7 +53,6 @@ def dotFromMethod(method: Method): List[String] = {
   }
 
   val methodExpressions = method
-    .asInstanceOf[Vertex] //TODO MP drop as soon as we have the remainder of the below in ODB graph api
     .out(EdgeTypes.AST)
     .hasLabel(NodeTypes.BLOCK)
     .out(EdgeTypes.AST)

--- a/joern-cli/src/main/resources/scripts/graph/graph-for-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/graph/graph-for-funcs.sc
@@ -46,8 +46,8 @@ final case class GraphForFuncsFunction(function: String,
                                        PDG: List[nodes.AstNode])
 final case class GraphForFuncsResult(functions: List[GraphForFuncsFunction])
 
-implicit val encodeEdge: Encoder[OdbEdge] =
-  (edge: OdbEdge) =>
+implicit val encodeEdge: Encoder[Edge] =
+  (edge: Edge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/graph-for-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/graph/graph-for-funcs.sc
@@ -76,20 +76,19 @@ implicit val encodeFuncResult: Encoder[GraphForFuncsResult] = deriveEncoder
     cpg.method.map { method =>
       val methodName = method.fullName
       val methodId = method.toString
-      val methodVertex: Vertex = method //TODO MP drop as soon as we have the remainder of the below in ODB graph api
 
       val astChildren = method.astMinusRoot.l
       val cfgChildren = method.out(EdgeTypes.CONTAINS).asScala.collect { case node: nodes.CfgNode => node }.toList
 
-      val local = new NodeSteps(
-        methodVertex
+      val local =
+        method
           .out(EdgeTypes.CONTAINS)
           .hasLabel(NodeTypes.BLOCK)
           .out(EdgeTypes.AST)
           .hasLabel(NodeTypes.LOCAL)
-          .cast[nodes.Local])
+          .cast[nodes.Local]
       val sink = local.evalType(".*").referencingIdentifiers.dedup
-      val source = new NodeSteps(methodVertex.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call]).nameNot("<operator>.*").dedup
+      val source = method.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call].nameNot("<operator>.*").dedup
 
       val pdgChildren = sink
         .reachableByFlows(source)

--- a/joern-cli/src/main/resources/scripts/graph/pdg-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/graph/pdg-for-funcs-dump.sc
@@ -126,7 +126,7 @@ final case class PdgForFuncsFunction(function: String, id: String, PDG: List[nod
         .hasLabel(NodeTypes.BLOCK)
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.LOCAL)
-        .cast[nodes.Local])
+        .cast[nodes.Local]
 
     val sink = local.referencingIdentifiers.dedup
     val source = method.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call].nameNot("<operator>.*").dedup

--- a/joern-cli/src/main/resources/scripts/graph/pdg-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/graph/pdg-for-funcs-dump.sc
@@ -83,8 +83,8 @@ import scala.jdk.CollectionConverters._
 
 implicit val encodeFuncFunction: Encoder[PdgForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[OdbEdge] =
-  (edge: OdbEdge) =>
+implicit val encodeEdge: Encoder[Edge] =
+  (edge: Edge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/pdg-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/graph/pdg-for-funcs-dump.sc
@@ -119,10 +119,9 @@ final case class PdgForFuncsFunction(function: String, id: String, PDG: List[nod
   methods.foreach { method =>
     val methodName = method.fullName
     val methodId = method.toString
-    val methodVertex: Vertex = method //TODO MP drop as soon as we have the remainder of the below in ODB graph api
 
-    val local = new NodeSteps(
-      methodVertex
+    val local =
+      method
         .out(EdgeTypes.CONTAINS)
         .hasLabel(NodeTypes.BLOCK)
         .out(EdgeTypes.AST)
@@ -130,7 +129,7 @@ final case class PdgForFuncsFunction(function: String, id: String, PDG: List[nod
         .cast[nodes.Local])
 
     val sink = local.referencingIdentifiers.dedup
-    val source = new NodeSteps(methodVertex.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call]).nameNot("<operator>.*").dedup
+    val source = method.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call].nameNot("<operator>.*").dedup
 
     val dependencies = sink
       .reachableBy(source).dedup

--- a/joern-cli/src/main/resources/scripts/graph/pdg.sc
+++ b/joern-cli/src/main/resources/scripts/graph/pdg.sc
@@ -20,15 +20,15 @@ type VertexEntry = (Long, String)
 type Pdg = (Option[String], List[EdgeEntry], List[VertexEntry])
 
 
-private def pdgFromEdges(edges: Traversal[OdbEdge]): (List[EdgeEntry], List[VertexEntry]) = {
+private def pdgFromEdges(edges: Traversal[Edge]): (List[EdgeEntry], List[VertexEntry]) = {
   val filteredEdges = edges.hasLabel(EdgeTypes.REACHING_DEF, EdgeTypes.CDG).dedup.l
 
   val (edgeResult, vertexResult) =
     filteredEdges.foldLeft((mutable.Set.empty[EdgeEntry], mutable.Set.empty[VertexEntry])) {
       case ((edgeList, vertexList), edge) =>
         val edgeEntry = (edge.inNode.id, edge.outNode.id)
-        val inVertexEntry = (edge.inNode.id, edge.inNode.propertyOption(NodeKeysOdb.CODE).getOrElse(""))
-        val outVertexEntry = (edge.outNode.id, edge.outNode.propertyOption(NodeKeysOdb.CODE).getOrElse(""))
+        val inVertexEntry = (edge.inNode.id, edge.inNode.propertyOption(NodeKeys.CODE).orElse(""))
+        val outVertexEntry = (edge.outNode.id, edge.outNode.propertyOption(NodeKeys.CODE).orElse(""))
 
         (edgeList += edgeEntry, vertexList ++= Set(inVertexEntry, outVertexEntry))
     }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -4,7 +4,6 @@ import io.shiftleft.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlow
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoaderConfig
-import overflowdb.OdbConfig
 
 object Cpg2Scpg {
 
@@ -31,7 +30,7 @@ object Cpg2Scpg {
     * @param filename name of the file that stores the cpg
     * */
   private def loadFromOdb(filename: String): Cpg = {
-    val odbConfig = OdbConfig.withDefaults().withStorageLocation(filename)
+    val odbConfig = overflowdb.Config.withDefaults().withStorageLocation(filename)
     val config = CpgLoaderConfig().withOverflowConfig(odbConfig).doNotCreateIndexesOnLoad
     io.shiftleft.codepropertygraph.cpgloading.CpgLoader.loadFromOverflowDb(config)
   }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.joern.console
 
-import io.shiftleft.console.{Help, Run}
+import io.shiftleft.console.{AmmoniteCodeBlockSeparator, Help, Run}
+
 object Predefined {
 
   /* ammonite tab completion is partly broken for scala > 2.12.8
@@ -21,20 +22,27 @@ object Predefined {
         |import scala.jdk.CollectionConverters._
         |implicit val resolver: ICallResolver = NoResolve
         |
-        |
       """.stripMargin
 
-  val forInteractiveShell: String = shared +
-    """
-      |import io.shiftleft.joern.console.Joern._
-      |
-    """.stripMargin + dynamicPredef()
+  val forInteractiveShell: String =
+    shared +
+      AmmoniteCodeBlockSeparator +
+      """
+        |import io.shiftleft.joern.console.Joern._
+        |
+      """.stripMargin +
+      AmmoniteCodeBlockSeparator +
+      dynamicPredef()
 
-  val forScripts: String = shared +
-    """
-      |import io.shiftleft.joern.console.Joern.{cpg =>_, _}
-      |
-  """.stripMargin + dynamicPredef()
+  val forScripts: String =
+    shared +
+      AmmoniteCodeBlockSeparator +
+      """
+        |import io.shiftleft.joern.console.Joern.{cpg =>_, _}
+        |
+      """.stripMargin +
+      AmmoniteCodeBlockSeparator +
+      dynamicPredef()
 
   def dynamicPredef(): String = {
     Run.codeForRunCommand() +

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
@@ -6,7 +6,6 @@ object Predefined {
   /* ammonite tab completion is partly broken for scala > 2.12.8
    * applying workaround for package wildcard imports from https://github.com/lihaoyi/Ammonite/issues/1009 */
   val shared: String = """
-        |import gremlin.scala.{`package` => _, _}
         |import io.shiftleft.console.{`package` => _, _}
         |import io.shiftleft.joern.console._
         |import io.shiftleft.joern.console.JoernConsole._
@@ -17,6 +16,8 @@ object Predefined {
         |import io.shiftleft.codepropertygraph.generated.edges._
         |import io.shiftleft.dataflowengineoss.language.{`package` => _, _}
         |import io.shiftleft.semanticcpg.language.{`package` => _, _}
+        |import overflowdb._
+        |import overflowdb.traversal._
         |import scala.jdk.CollectionConverters._
         |implicit val resolver: ICallResolver = NoResolve
         |

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
@@ -21,7 +21,6 @@ object Predefined {
         |import overflowdb.traversal._
         |import scala.jdk.CollectionConverters._
         |implicit val resolver: ICallResolver = NoResolve
-        |
       """.stripMargin
 
   val forInteractiveShell: String =
@@ -29,19 +28,14 @@ object Predefined {
       AmmoniteCodeBlockSeparator +
       """
         |import io.shiftleft.joern.console.Joern._
-        |
       """.stripMargin +
-      AmmoniteCodeBlockSeparator +
       dynamicPredef()
 
   val forScripts: String =
     shared +
-      AmmoniteCodeBlockSeparator +
       """
         |import io.shiftleft.joern.console.Joern.{cpg =>_, _}
-        |
       """.stripMargin +
-      AmmoniteCodeBlockSeparator +
       dynamicPredef()
 
   def dynamicPredef(): String = {

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.joern.console
 
-import io.shiftleft.console.{AmmoniteCodeBlockSeparator, Help, Run}
+import io.shiftleft.console.{Help, Run}
 
 object Predefined {
 
@@ -18,14 +18,13 @@ object Predefined {
         |import io.shiftleft.dataflowengineoss.language.{`package` => _, _}
         |import io.shiftleft.semanticcpg.language.{`package` => _, _}
         |import overflowdb._
-        |import overflowdb.traversal._
+        |import overflowdb.traversal.{help => _, _}
         |import scala.jdk.CollectionConverters._
         |implicit val resolver: ICallResolver = NoResolve
       """.stripMargin
 
   val forInteractiveShell: String =
     shared +
-      AmmoniteCodeBlockSeparator +
       """
         |import io.shiftleft.joern.console.Joern._
       """.stripMargin +

--- a/joern-cli/src/test/scala/io/shiftleft/joern/ConsoleTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/ConsoleTests.scala
@@ -49,21 +49,4 @@ class ConsoleTests extends WordSpec with Matchers {
       }
     }
   }
-
-  "help" should {
-    "allow getting long description via help object" in ConsoleFixture({ dir =>
-      new TestJoernConsole(dir)
-    }) { (console, codeDir) =>
-      File.usingTemporaryFile("console") { myScript =>
-        console.importCode(codeDir.toString)
-        val cpg = console.cpg
-        myScript.write(s"""
-                            | if (help.cpg.toString.isEmpty)
-                            |     throw new RuntimeException
-                            |""".stripMargin)
-        console.CpgScriptRunner(cpg).runScript(myScript.toString)
-      }
-    }
-  }
-
 }

--- a/joern-cli/src/test/scala/io/shiftleft/joern/ConsoleTests.scala
+++ b/joern-cli/src/test/scala/io/shiftleft/joern/ConsoleTests.scala
@@ -49,4 +49,21 @@ class ConsoleTests extends WordSpec with Matchers {
       }
     }
   }
+
+  "help" should {
+    "allow getting long description via help object" in ConsoleFixture({ dir =>
+      new TestJoernConsole(dir)
+    }) { (console, codeDir) =>
+      File.usingTemporaryFile("console") { myScript =>
+        console.importCode(codeDir.toString)
+        val cpg = console.cpg
+        myScript.write(s"""
+                            | if (help.cpg.toString.isEmpty)
+                            |     throw new RuntimeException
+                            |""".stripMargin)
+        console.CpgScriptRunner(cpg).runScript(myScript.toString)
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
important: this is part of the 'big bang' and should only be merged once we're happy with the migration guide and ready to merge all related PRs
depends on https://github.com/ShiftLeftSecurity/codepropertygraph/pull/923