### PR TITLE
Revert "use odb traversal instead of tinkerpop api (#334)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "0.12.1"
-val fuzzyc2cpgVersion = "1.1.79"
+val cpgVersion = "0.11.403"
+val fuzzyc2cpgVersion = "1.1.73"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/joern-cli/src/main/resources/scripts/c/const-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/c/const-funcs.sc
@@ -3,7 +3,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension._
 import io.shiftleft.dataflowengineoss.language._
-import overflowdb.traversal._
 
 private def callOutsAreConst(method: Method): Boolean = {
   method.start.callOut.calledMethod.internal.l.forall(_.signature.contains("const"))
@@ -17,7 +16,7 @@ private def parameterOpsAreConst(method: Method): Boolean = {
 }
 
 @main def main(): Set[Method] = {
-  cpg.method.internal.filter { method =>
+  (cpg: Cpg).method.internal.where { method =>
     !method.signature.contains("const") &&
       callOutsAreConst(method) &&
       parameterOpsAreConst(method)

--- a/joern-cli/src/main/resources/scripts/c/const-ish.sc
+++ b/joern-cli/src/main/resources/scripts/c/const-ish.sc
@@ -2,17 +2,15 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{Member, Method}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 @main def main(): Set[Method] = {
-  cpg.method
+  (cpg: Cpg).method
     .internal
-    .filter { method =>
-      method
-        .start
-        .assignments
-        .target
-        .reachableBy(method.parameter.filter(_.typeFullName.contains("const")))
-        .nonEmpty
+    .whereNonEmpty { method =>
+
+    method.start
+      .assignments
+      .target
+      .reachableBy(method.parameter.where(_.typeFullName.contains("const")))
   }.toSet
 }

--- a/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
+++ b/joern-cli/src/main/resources/scripts/c/malloc-leak.sc
@@ -2,11 +2,10 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.opnodes.Assignment
-import overflowdb.traversal._
 
 @main def main() = {
-  def allocated = cpg.call("malloc").inAssignment.target.dedup
-  def freed = cpg.call("free").argument(1)
-  def flowsFromAllocToFree = freed.reachableBy(allocated).toSet
+  val allocated = cpg.call("malloc").inAssignment.target.toSet
+  val freed = cpg.call("free").argument(1).l
+  val flowsFromAllocToFree = freed.start.reachableBy(allocated.start).toSet
   allocated.map(_.code).toSet.diff(flowsFromAllocToFree.map(_.code))
 }

--- a/joern-cli/src/main/resources/scripts/c/malloc-overflow.sc
+++ b/joern-cli/src/main/resources/scripts/c/malloc-overflow.sc
@@ -2,12 +2,11 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
 
 @main def main(): List[Call] = {
-  cpg
+  (cpg: Cpg)
     .call("malloc")
-    .filter { mallocCall =>
+    .where { mallocCall =>
       mallocCall.argument(1) match {
         case subCall: Call =>
           subCall.name == Operators.addition || subCall.name == Operators.multiplication

--- a/joern-cli/src/main/resources/scripts/c/pointer-to-int.sc
+++ b/joern-cli/src/main/resources/scripts/c/pointer-to-int.sc
@@ -3,7 +3,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, FieldId
 import io.shiftleft.codepropertygraph.generated.{Operators, nodes}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension._
-import overflowdb.traversal._
 
 private def expressionIsPointer(argument: Expression, isSubExpression: Boolean = false): Boolean = {
   argument match {
@@ -19,9 +18,9 @@ private def expressionIsPointer(argument: Expression, isSubExpression: Boolean =
 }
 
 @main def main(): List[nodes.Call] = {
-  cpg.assignment
-    .filter(assign => assign.source.isInstanceOf[Call] && assign.target.isInstanceOf[Identifier])
-    .filter { assignment =>
+  (cpg: Cpg).assignment
+    .where(assign => assign.source.isInstanceOf[Call] && assign.target.isInstanceOf[Identifier])
+    .where { assignment =>
       val target = assignment.target.asInstanceOf[Identifier]
       val source = assignment.source.asInstanceOf[Call]
 

--- a/joern-cli/src/main/resources/scripts/c/syscalls.sc
+++ b/joern-cli/src/main/resources/scripts/c/syscalls.sc
@@ -410,6 +410,6 @@ private val linuxSyscalls: Set[String] = Set(
 )
 
 @main def main(): List[Call] = {
-  cpg.call.filter(c => linuxSyscalls.contains(c.name)).l
+  (cpg: Cpg).call.where(c => linuxSyscalls.contains(c.name)).l
 }
 

--- a/joern-cli/src/main/resources/scripts/c/userspace-memory-access.sc
+++ b/joern-cli/src/main/resources/scripts/c/userspace-memory-access.sc
@@ -16,5 +16,5 @@ private val calls: Set[String] = Set(
 )
 
 @main def main(): List[Call] = {
-  cpg.call.filter(call => calls.contains(call.name)).l
+  (cpg: Cpg).call.where(call => calls.contains(call.name)).l
 }

--- a/joern-cli/src/main/resources/scripts/graph/ast-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/graph/ast-for-funcs-dump.sc
@@ -89,8 +89,8 @@ final case class AstForFuncsFunction(function: String, id: String, AST: List[Ast
 
 implicit val encodeFuncFunction: Encoder[AstForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[Edge] =
-  (edge: Edge) =>
+implicit val encodeEdge: Encoder[OdbEdge] =
+  (edge: OdbEdge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/ast-for-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/graph/ast-for-funcs.sc
@@ -88,8 +88,8 @@ final case class AstForFuncsResult(functions: List[AstForFuncsFunction])
 implicit val encodeFuncResult: Encoder[AstForFuncsResult] = deriveEncoder
 implicit val encodeFuncFunction: Encoder[AstForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[Edge] =
-  (edge: Edge) =>
+implicit val encodeEdge: Encoder[OdbEdge] =
+  (edge: OdbEdge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs-dump.sc
+++ b/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs-dump.sc
@@ -86,8 +86,8 @@ final case class CfgForFuncsFunction(function: String, id: String, CFG: List[nod
 
 implicit val encodeFuncFunction: Encoder[CfgForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[Edge] =
-  (edge: Edge) =>
+implicit val encodeEdge: Encoder[OdbEdge] =
+  (edge: OdbEdge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/graph/cfg-for-funcs.sc
@@ -87,8 +87,8 @@ final case class CfgForFuncsResult(functions: List[CfgForFuncsFunction])
 implicit val encodeFuncResult: Encoder[CfgForFuncsResult] = deriveEncoder
 implicit val encodeFuncFunction: Encoder[CfgForFuncsFunction] = deriveEncoder
 
-implicit val encodeEdge: Encoder[Edge] =
-  (edge: Edge) =>
+implicit val encodeEdge: Encoder[OdbEdge] =
+  (edge: OdbEdge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),

--- a/joern-cli/src/main/resources/scripts/graph/cfgToDot.sc
+++ b/joern-cli/src/main/resources/scripts/graph/cfgToDot.sc
@@ -50,11 +50,11 @@ def vertexToStr(vertex: Node): String = {
       case _ => "NA"
     }
 
-    s"${Paths.get(fileName).getFileName.toString}: ${vertex.property(NodeKeys.LINE_NUMBER)} ${vertex.property(NodeKeys.CODE)}"
+    s"${Paths.get(fileName).getFileName.toString}: ${vertex.property(NodeKeysOdb.LINE_NUMBER)} ${vertex.property(NodeKeysOdb.CODE)}"
   } catch { case _: Exception => "" }
 }
 
-def toDot(graph: Graph): String = {
+def toDot(graph: OdbGraph): String = {
   val buf = new StringBuffer()
 
   buf.append("digraph g {\n node[shape=plaintext];\n")

--- a/joern-cli/src/main/resources/scripts/graph/functions-to-dot.sc
+++ b/joern-cli/src/main/resources/scripts/graph/functions-to-dot.sc
@@ -5,8 +5,12 @@
 
 import ammonite.ops._
 
+import io.shiftleft.codepropertygraph.generated._
+import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import java.nio.file.Paths
 import java.net.URI
+import overflowdb._
+import overflowdb.traversal._
 import scala.annotation.tailrec
 
 def getTopLevelExpressions(expression: Node): List[Expression] = {
@@ -49,6 +53,7 @@ def dotFromMethod(method: Method): List[String] = {
   }
 
   val methodExpressions = method
+    .asInstanceOf[Vertex] //TODO MP drop as soon as we have the remainder of the below in ODB graph api
     .out(EdgeTypes.AST)
     .hasLabel(NodeTypes.BLOCK)
     .out(EdgeTypes.AST)

--- a/joern-cli/src/main/resources/scripts/graph/graph-for-funcs.sc
+++ b/joern-cli/src/main/resources/scripts/graph/graph-for-funcs.sc
@@ -46,8 +46,8 @@ final case class GraphForFuncsFunction(function: String,
                                        PDG: List[nodes.AstNode])
 final case class GraphForFuncsResult(functions: List[GraphForFuncsFunction])
 
-implicit val encodeEdge: Encoder[Edge] =
-  (edge: Edge) =>
+implicit val encodeEdge: Encoder[OdbEdge] =
+  (edge: OdbEdge) =>
     Json.obj(
       ("id", Json.fromString(edge.toString)),
       ("in", Json.fromString(edge.inNode.toString)),
@@ -76,19 +76,20 @@ implicit val encodeFuncResult: Encoder[GraphForFuncsResult] = deriveEncoder
     cpg.method.map { method =>
       val methodName = method.fullName
       val methodId = method.toString
+      val methodVertex: Vertex = method //TODO MP drop as soon as we have the remainder of the below in ODB graph api
 
       val astChildren = method.astMinusRoot.l
       val cfgChildren = method.out(EdgeTypes.CONTAINS).asScala.collect { case node: nodes.CfgNode => node }.toList
 
-      val local =
-        method
+      val local = new NodeSteps(
+        methodVertex
           .out(EdgeTypes.CONTAINS)
           .hasLabel(NodeTypes.BLOCK)
           .out(EdgeTypes.AST)
           .hasLabel(NodeTypes.LOCAL)
-          .cast[nodes.Local]
+          .cast[nodes.Local])
       val sink = local.evalType(".*").referencingIdentifiers.dedup
-      val source = method.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call].nameNot("<operator>.*").dedup
+      val source = new NodeSteps(methodVertex.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call]).nameNot("<operator>.*").dedup
 
       val pdgChildren = sink
         .reachableByFlows(source)

--- a/joern-cli/src/main/resources/scripts/graph/pdg.sc
+++ b/joern-cli/src/main/resources/scripts/graph/pdg.sc
@@ -20,15 +20,15 @@ type VertexEntry = (Long, String)
 type Pdg = (Option[String], List[EdgeEntry], List[VertexEntry])
 
 
-private def pdgFromEdges(edges: Traversal[Edge]): (List[EdgeEntry], List[VertexEntry]) = {
+private def pdgFromEdges(edges: Traversal[OdbEdge]): (List[EdgeEntry], List[VertexEntry]) = {
   val filteredEdges = edges.hasLabel(EdgeTypes.REACHING_DEF, EdgeTypes.CDG).dedup.l
 
   val (edgeResult, vertexResult) =
     filteredEdges.foldLeft((mutable.Set.empty[EdgeEntry], mutable.Set.empty[VertexEntry])) {
       case ((edgeList, vertexList), edge) =>
         val edgeEntry = (edge.inNode.id, edge.outNode.id)
-        val inVertexEntry = (edge.inNode.id, edge.inNode.propertyOption(NodeKeys.CODE).orElse(""))
-        val outVertexEntry = (edge.outNode.id, edge.outNode.propertyOption(NodeKeys.CODE).orElse(""))
+        val inVertexEntry = (edge.inNode.id, edge.inNode.propertyOption(NodeKeysOdb.CODE).getOrElse(""))
+        val outVertexEntry = (edge.outNode.id, edge.outNode.propertyOption(NodeKeysOdb.CODE).getOrElse(""))
 
         (edgeList += edgeEntry, vertexList ++= Set(inVertexEntry, outVertexEntry))
     }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/Cpg2Scpg.scala
@@ -4,6 +4,7 @@ import io.shiftleft.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlow
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoaderConfig
+import overflowdb.OdbConfig
 
 object Cpg2Scpg {
 
@@ -30,7 +31,7 @@ object Cpg2Scpg {
     * @param filename name of the file that stores the cpg
     * */
   private def loadFromOdb(filename: String): Cpg = {
-    val odbConfig = overflowdb.Config.withDefaults().withStorageLocation(filename)
+    val odbConfig = OdbConfig.withDefaults().withStorageLocation(filename)
     val config = CpgLoaderConfig().withOverflowConfig(odbConfig).doNotCreateIndexesOnLoad
     io.shiftleft.codepropertygraph.cpgloading.CpgLoader.loadFromOverflowDb(config)
   }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/Predefined.scala
@@ -1,12 +1,12 @@
 package io.shiftleft.joern.console
 
 import io.shiftleft.console.{Help, Run}
-
 object Predefined {
 
   /* ammonite tab completion is partly broken for scala > 2.12.8
    * applying workaround for package wildcard imports from https://github.com/lihaoyi/Ammonite/issues/1009 */
   val shared: String = """
+        |import gremlin.scala.{`package` => _, _}
         |import io.shiftleft.console.{`package` => _, _}
         |import io.shiftleft.joern.console._
         |import io.shiftleft.joern.console.JoernConsole._
@@ -17,25 +17,23 @@ object Predefined {
         |import io.shiftleft.codepropertygraph.generated.edges._
         |import io.shiftleft.dataflowengineoss.language.{`package` => _, _}
         |import io.shiftleft.semanticcpg.language.{`package` => _, _}
-        |import overflowdb._
-        |import overflowdb.traversal.{help => _, _}
         |import scala.jdk.CollectionConverters._
         |implicit val resolver: ICallResolver = NoResolve
+        |
+        |
       """.stripMargin
 
-  val forInteractiveShell: String =
-    shared +
-      """
-        |import io.shiftleft.joern.console.Joern._
-      """.stripMargin +
-      dynamicPredef()
+  val forInteractiveShell: String = shared +
+    """
+      |import io.shiftleft.joern.console.Joern._
+      |
+    """.stripMargin + dynamicPredef()
 
-  val forScripts: String =
-    shared +
-      """
-        |import io.shiftleft.joern.console.Joern.{cpg =>_, _}
-      """.stripMargin +
-      dynamicPredef()
+  val forScripts: String = shared +
+    """
+      |import io.shiftleft.joern.console.Joern.{cpg =>_, _}
+      |
+  """.stripMargin + dynamicPredef()
 
   def dynamicPredef(): String = {
     Run.codeForRunCommand() +


### PR DESCRIPTION
This reverts commit 53ce3b10c069f241a8e1a21db49b7be0201e9b7a.