### PR TITLE
Make `Semantics` implicit available by default

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernConsole.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernConsole.scala
@@ -48,6 +48,8 @@ class JoernConsole extends Console[JoernProject](JoernAmmoniteExecutor, new Joer
 
   override def config: ConsoleConfig = JoernConsole.config
 
+  implicit def semantics : Semantics = context.semantics
+
   implicit def context: EngineContext =
     workspace.getActiveProject
       .map(x => EngineContext(x.asInstanceOf[JoernProject].context.semantics))

--- a/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernConsole.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/console/JoernConsole.scala
@@ -48,7 +48,7 @@ class JoernConsole extends Console[JoernProject](JoernAmmoniteExecutor, new Joer
 
   override def config: ConsoleConfig = JoernConsole.config
 
-  implicit def semantics : Semantics = context.semantics
+  implicit def semantics: Semantics = context.semantics
 
   implicit def context: EngineContext =
     workspace.getActiveProject


### PR DESCRIPTION
Fix a recent regression: the implicit of type `Semantics` was no longer available by default.