### PR TITLE
Completed initial version of `joern-export`

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
@@ -14,15 +14,16 @@ case class ExporterConfig(cpgFileName: String = "cpg.bin", outDir: String = "out
 object JoernExport extends App {
 
   parseConfig.foreach { config =>
-    if (!File(config.cpgFileName).exists) {
-      System.err.println(s"CPG at ${config.cpgFileName} does not exist. Bailing out.")
+    if (File(config.outDir).exists) {
+      System.err.println(s"Output directory ${config.outDir} already exists. Bailing out.")
     } else {
-      val cpg = CpgBasedTool.loadFromOdb(config.cpgFileName)
-      addDataFlowOverlayIfNonExistent(cpg)
-      val context = new LayerCreatorContext(cpg)
-      if (File(config.outDir).exists) {
-        System.err.println(s"Output directory ${config.outDir} already exists. Bailing out.")
+      if (!File(config.cpgFileName).exists) {
+        System.err.println(s"CPG at ${config.cpgFileName} does not exist. Bailing out.")
       } else {
+        val cpg = CpgBasedTool.loadFromOdb(config.cpgFileName)
+        addDataFlowOverlayIfNonExistent(cpg)
+        val context = new LayerCreatorContext(cpg)
+
         mkdir(File(config.outDir))
         implicit val semantics: Semantics = JoernWorkspaceLoader.defaultSemantics
         if (semantics.elements.isEmpty) {

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
@@ -3,15 +3,41 @@ package io.shiftleft.joern
 import better.files.File
 import better.files.Dsl._
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.dataflowengineoss.layers.dataflows.{Cpg14DumpOptions, DumpCpg14, OssDataFlow, OssDataFlowOptions}
+import io.shiftleft.dataflowengineoss.layers.dataflows.{
+  Cpg14DumpOptions,
+  DdgDumpOptions,
+  DumpCpg14,
+  DumpDdg,
+  DumpPdg,
+  OssDataFlow,
+  OssDataFlowOptions,
+  PdgDumpOptions
+}
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.joern.console.JoernWorkspaceLoader
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+import io.shiftleft.semanticcpg.layers.{
+  AstDumpOptions,
+  CdgDumpOptions,
+  CfgDumpOptions,
+  DumpAst,
+  DumpCdg,
+  DumpCfg,
+  LayerCreatorContext
+}
 
-case class ExporterConfig(cpgFileName: String = "cpg.bin", outDir: String = "out")
+case class ExporterConfig(cpgFileName: String = "cpg.bin", outDir: String = "out", repr: String = "cpg14")
 
 object JoernExport extends App {
+
+  object Representations {
+    val ast = "ast"
+    val cfg = "cfg"
+    val ddg = "ddg"
+    val cdg = "cdg"
+    val pdg = "pdg"
+    val cpg14 = "cpg14"
+  }
 
   private def parseConfig: Option[ExporterConfig] =
     new scopt.OptionParser[ExporterConfig]("joern-export") {
@@ -24,6 +50,9 @@ object JoernExport extends App {
       opt[String]("out")
         .text("output directory")
         .action((x, c) => c.copy(outDir = x))
+      opt[String]("repr")
+        .text("representation to extract: [ast|cfg|ddg|cdg|pdg|cpg14]")
+        .action((x, c) => c.copy(repr = x))
     }.parse(args, ExporterConfig())
 
   parseConfig.foreach { config =>
@@ -42,8 +71,23 @@ object JoernExport extends App {
         if (semantics.elements.isEmpty) {
           System.err.println("Warning: semantics are empty.")
         }
-        val opts = Cpg14DumpOptions(config.outDir)
-        new DumpCpg14(opts).create(context)
+
+        config.repr match {
+          case Representations.ast =>
+            new DumpAst(AstDumpOptions(config.outDir)).create(context)
+          case Representations.cfg =>
+            new DumpCfg(CfgDumpOptions(config.outDir)).create(context)
+          case Representations.ddg =>
+            new DumpDdg(DdgDumpOptions(config.outDir)).create(context)
+          case Representations.cdg =>
+            new DumpCdg(CdgDumpOptions(config.outDir)).create(context)
+          case Representations.pdg =>
+            new DumpPdg(PdgDumpOptions(config.outDir)).create(context)
+          case Representations.cpg14 =>
+            new DumpCpg14(Cpg14DumpOptions(config.outDir)).create(context)
+          case repr =>
+            System.err.println(s"unknown representation: $repr. Baling out.")
+        }
       }
     }
   }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
@@ -13,6 +13,18 @@ case class ExporterConfig(cpgFileName: String = "cpg.bin", outDir: String = "out
 
 object JoernExport extends App {
 
+  private def parseConfig: Option[ExporterConfig] =
+    new scopt.OptionParser[ExporterConfig](getClass.getSimpleName) {
+      help("help")
+      arg[String]("cpg")
+        .text("CPG file name")
+        .optional()
+        .action((x, c) => c.copy(cpgFileName = x))
+      opt[String]("out")
+        .text("output directory")
+        .action((x, c) => c.copy(outDir = x))
+    }.parse(args, ExporterConfig())
+
   parseConfig.foreach { config =>
     if (File(config.outDir).exists) {
       System.err.println(s"Output directory ${config.outDir} already exists. Bailing out.")
@@ -43,17 +55,5 @@ object JoernExport extends App {
       new OssDataFlow(opts).run(context)
     }
   }
-
-  private def parseConfig: Option[ExporterConfig] =
-    new scopt.OptionParser[ExporterConfig](getClass.getSimpleName) {
-      help("help")
-      arg[String]("cpg")
-        .text("CPG file name")
-        .optional()
-        .action((x, c) => c.copy(cpgFileName = x))
-      opt[String]("out")
-        .text("output directory")
-        .action((x, c) => c.copy(cpgFileName = x))
-    }.parse(args, ExporterConfig())
 
 }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernExport.scala
@@ -14,10 +14,11 @@ case class ExporterConfig(cpgFileName: String = "cpg.bin", outDir: String = "out
 object JoernExport extends App {
 
   private def parseConfig: Option[ExporterConfig] =
-    new scopt.OptionParser[ExporterConfig](getClass.getSimpleName) {
+    new scopt.OptionParser[ExporterConfig]("joern-export") {
+      head("Dump intermediate graph representations of code onto disk")
       help("help")
       arg[String]("cpg")
-        .text("CPG file name")
+        .text("CPG file name ('cpg.bin' by default)")
         .optional()
         .action((x, c) => c.copy(cpgFileName = x))
       opt[String]("out")


### PR DESCRIPTION
Completed work on initial version of `joern-export`, a command line tool for exporting different intraprocedural intermediate representations into dot format. The exporter is quite fast. See an example below where we export ASTs for all functions in VLC in 38 seconds. Exports 2014 Code Property Graph by default.

![export](https://user-images.githubusercontent.com/1379115/94375808-94a9db00-0116-11eb-8ed8-484fecb1ab2e.png)
