### PR TITLE
Fix local Dockerfile issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ln -sf python3 /usr/bin/python
 ENV SBT_VERSION 1.3.13
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
-RUN curl -sL "https://piccolo.link/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local
+RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local
 
 # building joern
 RUN git clone https://github.com/ShiftLeftSecurity/joern.git && cd joern && sbt stage


### PR DESCRIPTION
This Pull request is in response to #360 

### Issue:
For some reason when the docker build failed on my machine at the step `RUN curl -sL "https://piccolo.link/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local` and I have determined that the issue is downloading the tar file. It seems as though the file is not located at that address anymore.

### Solution:
The official [sbt website](https://www.scala-sbt.org/download.html) offers downloads for each version of sbt straight from GitHub. Swapping the location of sbt from `https://piccolo.link/sbt-$SBT_VERSION.tgz` to `https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz` seems to fix the issue