### PR TITLE
Bring in member access fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "1.2.4"
+val cpgVersion = "1.2.6"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,


### PR DESCRIPTION
New `codepropertygraph` fixes overtainting issue with access paths. This PR brings in that fix.