### PR TITLE
Implement `joern-stats` subtool

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
@@ -18,7 +18,7 @@ object JoernStats extends App {
       head("Prints statistics on various nodes found in Code Property Graphs")
       help("help")
 
-      arg[String]("cpg")
+      arg[String]("cpg.bin")
         .text("Path to the Code Property Graph file")
         .action((name, c) => c.copy(cpgFileName = name))
     }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
@@ -31,7 +31,6 @@ object JoernStats extends App {
       sys.exit(1)
     }
 
-    println("METADATA  " + cpg.metaData.size)
     println("NAMESPACE " + cpg.namespace.size)
     println("TYPE_DECL " + cpg.typeDecl.size)
     println("METHOD    " + cpg.method.size)

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
@@ -36,7 +36,6 @@ object JoernStats extends App {
     println("TYPE_DECL " + cpg.typeDecl.size)
     println("METHOD    " + cpg.method.size)
     println("CALL      " + cpg.call.size)
-    println("FINDING   " + cpg.graph.nodes(NodeTypes.FINDING).size)
     cpg.close()
   }
 }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
@@ -1,0 +1,42 @@
+package io.shiftleft.joern
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.joern.console.JoernWorkspaceLoader
+import overflowdb.traversal.{Traversal, jIteratortoTraversal}
+
+case class StatsConfig(cpgFileName: String = "cpg.bin")
+
+object JoernStats extends App {
+  private def parseConfig: Option[StatsConfig] = {
+    new scopt.OptionParser[StatsConfig]("joern-stats") {
+      head("Prints statistics on various nodes found in Code Property Graphs")
+      help("help")
+
+      arg[String]("cpg")
+        .text("Path to the Code Property Graph file")
+        .action((name, c) => c.copy(cpgFileName = name))
+    }
+  }.parse(args, StatsConfig())
+
+  parseConfig.foreach { config =>
+    val cpg = CpgBasedTool.loadFromOdb(config.cpgFileName)
+    if (cpg.metaData.isEmpty) {
+      println("ERROR: could not load Code Property Graph file at path `" + config.cpgFileName + "`. Exiting.")
+      sys.exit(1)
+    }
+
+    println("METADATA  " + cpg.metaData.size)
+    println("NAMESPACE " + cpg.namespace.size)
+    println("TYPE_DECL " + cpg.typeDecl.size)
+    println("METHOD    " + cpg.method.size)
+    println("CALL      " + cpg.call.size)
+    println("FINDING   " + cpg.graph.nodes(NodeTypes.FINDING).size)
+    cpg.close()
+  }
+}

--- a/joern-cli/src/universal/joern-stats
+++ b/joern-cli/src/universal/joern-stats
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
+SCRIPT="$SCRIPT_ABS_DIR"/bin/joern-stats
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"

--- a/joern-stats
+++ b/joern-stats
@@ -1,0 +1,1 @@
+./joern-cli/target/universal/stage/joern-stats


### PR DESCRIPTION
Useful for printing statistics on Code Property Graph files
when an interactive session is too overkill.

Example usage:
```
$ ./joern-stats example.cpg.bin.zip
METADATA  1
NAMESPACE 3827
TYPE_DECL 29983
METHOD    262613
CALL      5708704
FINDING   275
```