### PR TITLE
Integrate plume into `joern-parse`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,
   Resolver.bintrayRepo("shiftleft", "maven"),
   Resolver.bintrayRepo("mpollmeier", "maven"),
+  Resolver.bintrayRepo("plume-oss", "maven"),
   "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public",
 )
 

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -13,6 +13,12 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
   "io.github.plume-oss"    % "plume" % "0.0.1",
+
+  "org.jetbrains.kotlin" % "kotlin-stdlib-jdk8" % "1.3.72" % Runtime,
+  "org.jetbrains.kotlin" % "kotlin-reflect" % "1.3.72" % Runtime,
+  "org.lz4" % "lz4-java" % "1.7.1" % Runtime,
+  "org.soot-oss" % "soot" % "4.2.1" % Runtime,
+
   "com.lihaoyi" %% "ammonite" % "2.0.4" cross CrossVersion.full,
   "com.github.scopt" %% "scopt" % "3.7.1",
   "com.github.pathikrit" %% "better-files" % "3.8.0",

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
+  "io.github.plume-oss"    % "plume" % "0.0.1",
   "com.lihaoyi" %% "ammonite" % "2.0.4" cross CrossVersion.full,
   "com.github.scopt" %% "scopt" % "3.7.1",
   "com.github.pathikrit" %% "better-files" % "3.8.0",

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
-  "io.github.plume-oss"    % "plume" % "0.0.1",
+  "io.github.plume-oss"    % "plume" % "0.0.2",
 
   "org.jetbrains.kotlin" % "kotlin-stdlib-jdk8" % "1.3.72" % Runtime,
   "org.jetbrains.kotlin" % "kotlin-reflect" % "1.3.72" % Runtime,

--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -21,13 +21,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.1" % Test,
 )
 
-excludeDependencies ++= Seq(
-  // This project uses Logback in place of Log4j
-  ExclusionRule("org.apache.logging.log4j", "log4j-slf4j-impl"),
-  ExclusionRule("org.slf4j", "slf4j-simple"),
-  ExclusionRule("ch.qos.logback", "logback-classic"),
-)
-
 enablePlugins(JavaAppPackaging)
 scriptClasspath := Seq("*") //wildcard import from staged `lib` dir, for simplicity and also to avoid `line too long` error on windows
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.joern
 
+import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 
 import scala.util.control.NonFatal
@@ -17,12 +18,12 @@ object JoernParse extends App {
   }
 
   def generateCpg(config: ParserConfig): Unit = {
-
     if (!config.enhanceOnly) {
-      println(config.language)
       config.language match {
         case "c" =>
           createCpgFromCSourceCode(config)
+        case "java" =>
+          createCpgFromJavaSourceCode(config)
         case _ =>
           println(s"Error: Language ${config.language} not recognized")
           return
@@ -52,6 +53,11 @@ object JoernParse extends App {
         .runAndOutput(config.inputPaths, config.cFrontendConfig.sourceFileExtensions, Some(config.outputCpgFile))
         .close()
     }
+  }
+
+  private def createCpgFromJavaSourceCode(config: JoernParse.ParserConfig): Unit = {
+    println("TODO: connect plume for Java CPG creation")
+    Cpg.withStorage(config.outputCpgFile).close()
   }
 
   case class ParserConfig(inputPaths: Set[String] = Set.empty,

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -61,10 +61,15 @@ object JoernParse extends App {
 
   private def createCpgFromJavaSourceCode(config: JoernParse.ParserConfig): Unit = {
     Using(DriverFactory.invoke(GraphDatabase.OVERFLOWDB).asInstanceOf[OverflowDbDriver]) { driver =>
-      driver.dbfilename(config.outputCpgFile)
+      val outFile = File(config.outputCpgFile)
+      if (outFile.exists) {
+        println(s"Output file ${config.outputCpgFile} exists. Removing first.")
+        outFile.delete()
+      }
+      driver.setStorageLocation(config.outputCpgFile)
       config.inputPaths.foreach { inputPath =>
         val file = new java.io.File(inputPath)
-        val extractor = new Extractor(driver, file)
+        val extractor = new Extractor(driver)
         extractor.load(file)
         extractor.project()
       }

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -22,7 +22,14 @@ object JoernParse extends App {
   def generateCpg(config: ParserConfig): Unit = {
 
     if (!config.enhanceOnly) {
-      createCpgFromCSourceCode(config)
+      println(config.language)
+      config.language match {
+        case "c" =>
+          createCpgFromCSourceCode(config)
+        case _ =>
+          logger.error(s"Language ${config.language} not recognized")
+          return
+      }
     }
 
     if (config.enhance) {
@@ -55,6 +62,7 @@ object JoernParse extends App {
                           enhance: Boolean = true,
                           dataFlow: Boolean = true,
                           enhanceOnly: Boolean = false,
+                          language : String = "c",
                           cFrontendConfig: CFrontendConfig = CFrontendConfig(),
                           preprocessorConfig: PreprocessorConfig = PreprocessorConfig())
 
@@ -89,6 +97,9 @@ object JoernParse extends App {
       opt[Unit]("nodataflow")
         .text("do not perform data flow analysis")
         .action((x, c) => c.copy(dataFlow = false))
+      opt[String]("language")
+          .text("source language: [c|java]")
+          .action((x, c) => c.copy(language = x))
       opt[String]("source-file-ext")
         .unbounded()
         .text("source file extensions to include when gathering source files. Defaults are .c, .cc, .cpp, .h and .hpp")

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -17,7 +17,7 @@ object JoernParse extends App {
       generateCpg(config)
     } catch {
       case NonFatal(ex) =>
-        println("Error: Failed to enhance CPG.", ex)
+        println("Error: Failed to generate/enhance CPG.", ex)
     }
   }
 
@@ -98,27 +98,35 @@ object JoernParse extends App {
   }
 
   def parseConfig: Option[ParserConfig] =
-    new scopt.OptionParser[ParserConfig](getClass.getSimpleName) {
-      help("help")
-      arg[String]("<input-dir>")
+    new scopt.OptionParser[ParserConfig]("joern-parse") {
+
+      arg[String]("input-files")
         .unbounded()
-        .text("source directories containing C/C++ code")
+        .text("directories containing: C/C++ source | Java source code or classes")
         .action((x, c) => c.copy(inputPaths = c.inputPaths + x))
+
+      opt[String]("language")
+        .text("source language: [c|java]. Default: c")
+        .action((x, c) => c.copy(language = x))
+
       opt[String]("out")
         .text("output filename")
         .action((x, c) => c.copy(outputCpgFile = x))
+
+      note("Enhancement stage")
+
       opt[Unit]("noenhance")
-        .text("run language frontend but do not enhance the CPG to create an SCPG")
+        .text("do not run enhancement stage")
         .action((x, c) => c.copy(enhance = false))
       opt[Unit]("enhanceonly")
-        .text("Only run the enhancer")
+        .text("Only run the enhancement stage")
         .action((x, c) => c.copy(enhanceOnly = true))
       opt[Unit]("nodataflow")
-        .text("do not perform data flow analysis")
+        .text("do not perform data flow analysis in enhancement stage")
         .action((x, c) => c.copy(dataFlow = false))
-      opt[String]("language")
-        .text("source language: [c|java]")
-        .action((x, c) => c.copy(language = x))
+
+      note("Options for C/C++")
+
       opt[String]("source-file-ext")
         .unbounded()
         .text("source file extensions to include when gathering source files. Defaults are .c, .cc, .cpp, .h and .hpp")
@@ -150,6 +158,8 @@ object JoernParse extends App {
       opt[String]("preprocessor-executable")
         .text("path to the preprocessor executable")
         .action((s, cfg) => cfg.copy(preprocessorConfig = cfg.preprocessorConfig.copy(preprocessorExecutable = s)))
+
+      note("Misc")
       help("help").text("display this help message")
     }.parse(args, ParserConfig())
 

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernParse.scala
@@ -1,21 +1,18 @@
 package io.shiftleft.joern
 
 import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
-import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
 
 object JoernParse extends App {
   val DEFAULT_CPG_OUT_FILE = "cpg.bin"
 
-  private val logger = LoggerFactory.getLogger(getClass)
-
   parseConfig.foreach { config =>
     try {
       generateCpg(config)
     } catch {
       case NonFatal(ex) =>
-        logger.error("Failed to enhance CPG.", ex)
+        println("Error: Failed to enhance CPG.", ex)
     }
   }
 
@@ -27,7 +24,7 @@ object JoernParse extends App {
         case "c" =>
           createCpgFromCSourceCode(config)
         case _ =>
-          logger.error(s"Language ${config.language} not recognized")
+          println(s"Error: Language ${config.language} not recognized")
           return
       }
     }
@@ -62,7 +59,7 @@ object JoernParse extends App {
                           enhance: Boolean = true,
                           dataFlow: Boolean = true,
                           enhanceOnly: Boolean = false,
-                          language : String = "c",
+                          language: String = "c",
                           cFrontendConfig: CFrontendConfig = CFrontendConfig(),
                           preprocessorConfig: PreprocessorConfig = PreprocessorConfig())
 
@@ -98,12 +95,14 @@ object JoernParse extends App {
         .text("do not perform data flow analysis")
         .action((x, c) => c.copy(dataFlow = false))
       opt[String]("language")
-          .text("source language: [c|java]")
-          .action((x, c) => c.copy(language = x))
+        .text("source language: [c|java]")
+        .action((x, c) => c.copy(language = x))
       opt[String]("source-file-ext")
         .unbounded()
         .text("source file extensions to include when gathering source files. Defaults are .c, .cc, .cpp, .h and .hpp")
-        .action((pat, cfg) => cfg.copy(cFrontendConfig = cfg.cFrontendConfig.copy(sourceFileExtensions = cfg.cFrontendConfig.sourceFileExtensions + pat)))
+        .action((pat, cfg) =>
+          cfg.copy(cFrontendConfig =
+            cfg.cFrontendConfig.copy(sourceFileExtensions = cfg.cFrontendConfig.sourceFileExtensions + pat)))
       opt[String]("include")
         .unbounded()
         .text("header include files")

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernStats.scala
@@ -1,14 +1,6 @@
 package io.shiftleft.joern
 
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
-import io.shiftleft.codepropertygraph.generated.nodes.MethodParameterIn
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengineoss.language._
-import io.shiftleft.dataflowengineoss.queryengine.{EngineConfig, EngineContext}
-import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
-import io.shiftleft.joern.console.JoernWorkspaceLoader
-import overflowdb.traversal.{Traversal, jIteratortoTraversal}
 
 case class StatsConfig(cpgFileName: String = "cpg.bin")
 

--- a/joern-cli/src/universal/joern-parse
+++ b/joern-cli/src/universal/joern-parse
@@ -13,5 +13,4 @@ if [ ! -f "$SCRIPT" ]; then
     exit 1
 fi
 
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@" --noenhance
-$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@" --enhanceonly
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml "$@"


### PR DESCRIPTION
You can now import java code and the load the corresponding CPG as follows:
* `./joern-parse --language java ../plume/src/test/resources/extractor_tests/dir_test`
* `./joern`
*  `importCpg("cpg.bin")`
* `cpg.method.l`

I have also cleaned up the `joern-parse --help` text a bit and grouped items. In `joern-parse.sh`, a hack has been removed that provides better performance but severally complicated matters.

The next step is to make `importCode` work to enable importing Java code directly from the shell and in joern scripts. This is a bit tricky because we now have two alternative frontends for Java, one available in both joern and ocular, and one available only in ocular.