### PR TITLE
Add `lib` symlink to allow plugins in dev tree

### DIFF
--- a/lib
+++ b/lib
@@ -1,0 +1,1 @@
+joern-cli/target/universal/stage/lib/


### PR DESCRIPTION
Created a symlink from `lib` to `joern-cli/target/universal/stage/lib/` so that both in the installed distribution and in the development tree, plugins can be installed in `config.install.root` + `lib`.
