### PR TITLE
`JoernScan`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "1.3.26+1-b320b5ca"
+val cpgVersion = "1.3.28"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.shiftleft"
 ThisBuild / scalaVersion := "2.13.0"
 ThisBuild /Test /fork := true
 
-val cpgVersion = "1.3.26"
+val cpgVersion = "1.3.26+1-b320b5ca"
 
 ThisBuild / resolvers ++= Seq(
   Resolver.mavenLocal,

--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -1,0 +1,78 @@
+package io.shiftleft.joern
+
+import io.shiftleft.console.scan.{ScanPass, outputFindings}
+import io.shiftleft.console.{BridgeBase, DefaultArgumentProvider, JoernProduct, Query, QueryDatabase}
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+import io.shiftleft.joern.console.AmmoniteBridge
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+
+import scala.reflect.runtime.universe._
+
+case class JoernScanConfig(src: String = "", overwrite: Boolean = false, store: Boolean = false)
+
+object JoernScan extends App with BridgeBase {
+
+  def parseScanConfig(args: Array[String]): Option[JoernScanConfig] = {
+    new scopt.OptionParser[JoernScanConfig]("joern-scan") {
+      head("Scan code")
+      help("help")
+      arg[String]("src")
+        .text("source code directory to scan")
+        .action((x, c) => c.copy(src = x))
+
+      opt[Unit]("overwrite")
+        .action((_, c) => c.copy(overwrite = true))
+        .text("Overwrite CPG if it already exists")
+
+      opt[Unit]("store")
+        .action((_, c) => c.copy(store = true))
+        .text("Store graph changes made by bundle")
+    }
+  }.parse(args, JoernScanConfig())
+
+  parseScanConfig(args).foreach { config =>
+    val shellConfig = io.shiftleft.console
+      .Config()
+      .copy(bundleToRun = Some("scan"), src = Some(config.src), overwrite = config.overwrite, store = config.store)
+    runAmmonite(shellConfig, JoernProduct)
+  }
+
+  override protected def predefPlus(lines: List[String]) = AmmoniteBridge.predefPlus(lines)
+  override protected def shutdownHooks = AmmoniteBridge.shutdownHooks
+  override protected def promptStr() = AmmoniteBridge.promptStr()
+}
+
+object Scan {
+  val overlayName = "scan"
+  val description = "Joern Code Scanner"
+  def defaultOpts = new ScanOptions()
+}
+
+class ScanOptions() extends LayerCreatorOptions {}
+
+class Scan(options: ScanOptions)(implicit engineContext: EngineContext) extends LayerCreator {
+
+  override val overlayName: String = Scan.overlayName
+  override val description: String = Scan.description
+
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
+    val queryDb = new QueryDatabase(new JoernDefaultArgumentProvider())
+    val allQueries: List[Query] = queryDb.allQueries
+    if (allQueries.isEmpty) {
+      println("You have not installed any query bundles")
+    }
+    runPass(new ScanPass(context.cpg, allQueries), context, storeUndoInfo)
+    outputFindings(context.cpg)
+  }
+}
+
+class JoernDefaultArgumentProvider(implicit context: EngineContext) extends DefaultArgumentProvider {
+
+  override def defaultArgument(method: MethodSymbol, im: InstanceMirror, x: Symbol, i: Int): Option[Any] = {
+    if (x.typeSignature.toString.endsWith("EngineContext")) {
+      Some(context)
+    } else {
+      super.defaultArgument(method, im, x, i)
+    }
+  }
+}

--- a/joern-cli/src/universal/joern-scan
+++ b/joern-cli/src/universal/joern-scan
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    SCRIPT_ABS_PATH=$(greadlink -f "$0")
+else
+    SCRIPT_ABS_PATH=$(readlink -f "$0")
+fi
+SCRIPT_ABS_DIR=$(dirname "$SCRIPT_ABS_PATH")
+SCRIPT="$SCRIPT_ABS_DIR"/bin/joern-scan
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "Unable to find $SCRIPT, have you created the distribution?"
+    exit 1
+fi
+
+$SCRIPT -J-XX:+UseG1GC -J-XX:CompressedClassSpaceSize=128m -Dlog4j.configurationFile="$SCRIPT_ABS_DIR"/conf/log4j2.xml -J-XX:+UseStringDeduplication "$@"
+

--- a/joern-scan
+++ b/joern-scan
@@ -1,0 +1,1 @@
+./joern-cli/target/universal/stage/joern-scan


### PR DESCRIPTION
Brings `joern-scan` from `query-database` to main joern. Goal is to ensure that the query database only contains queries yet `joern-scan` can be used from it.
Depends on: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1071