### PR TITLE
Add `--no-download` flag for `joern-install.sh`

### DIFF
--- a/joern-install.sh
+++ b/joern-install.sh
@@ -30,17 +30,37 @@ check_installed() {
   fi
 }
 
-# Confirm install with user.
+NON_INTERACTIVE=false
+NO_DOWNLOAD=false
+
+while test $# -gt 0
+do
+    case "$1" in
+        --non-interactive)
+          NON_INTERACTIVE=true
+            ;;
+        --no-download)
+          NO_DOWNLOAD=true
+            ;;
+        --*) echo "bad option $1"
+            ;;
+        *) echo "argument $1"
+            ;;
+    esac
+    shift
+done
+
 JOERN_DEFAULT_INSTALL_DIR=~/bin/joern
 JOERN_DEFAULT_LINK_DIR="/usr/local/bin"
 JOERN_DEFAULT_VERSION=""
 
-if [ $# -ne 0 ] && [ "$1" = "--non-interactive" ]; then
+if [ $NON_INTERACTIVE = true ]; then
   echo "non-interactive mode, using defaults"
   JOERN_INSTALL_DIR=$JOERN_DEFAULT_INSTALL_DIR
   JOERN_LINK_DIR=$JOERN_DEFAULT_LINK_DIR
   JOERN_VERSION=$JOERN_DEFAULT_VERSION
 else
+    # Confirm install with user.
     printf "This script will download and install the Joern tools on your machine. Proceed? [Y/n]: "
     read -r JOERN_PROMPT_ANSWER
 
@@ -74,14 +94,19 @@ fi
 
 mkdir -p $JOERN_INSTALL_DIR
 # Download and extract the Joern CLI
+
 check_installed "curl"
 
-
-if [ "$JOERN_VERSION" = "" ]; then
-  curl -L "https://github.com/ShiftLeftSecurity/joern/releases/latest/download/joern-cli.zip" -o "$SCRIPT_ABS_DIR/joern-cli.zip"
+if [ $NO_DOWNLOAD ]; then
+    sbt createDistribution
 else
-  curl -L "https://github.com/ShiftLeftSecurity/joern/releases/download/$JOERN_VERSION/joern-cli.zip" -o "$SCRIPT_ABS_DIR/joern-cli.zip"
+  if [ "$JOERN_VERSION" = "" ]; then
+    curl -L "https://github.com/ShiftLeftSecurity/joern/releases/latest/download/joern-cli.zip" -o "$SCRIPT_ABS_DIR/joern-cli.zip"
+  else
+    curl -L "https://github.com/ShiftLeftSecurity/joern/releases/download/$JOERN_VERSION/joern-cli.zip" -o "$SCRIPT_ABS_DIR/joern-cli.zip"
+  fi
 fi
+
 
 unzip -qo -d "$JOERN_INSTALL_DIR" "$SCRIPT_ABS_DIR"/joern-cli.zip
 rm "$SCRIPT_ABS_DIR"/joern-cli.zip

--- a/joern-install.sh
+++ b/joern-install.sh
@@ -41,32 +41,32 @@ if [ $# -ne 0 ] && [ "$1" = "--non-interactive" ]; then
   JOERN_LINK_DIR=$JOERN_DEFAULT_LINK_DIR
   JOERN_VERSION=$JOERN_DEFAULT_VERSION
 else
-    echo -n "This script will download and install the Joern tools on your machine. Proceed? [Y/n]: "
+    printf "This script will download and install the Joern tools on your machine. Proceed? [Y/n]: "
     read -r JOERN_PROMPT_ANSWER
 
     if [ "$JOERN_PROMPT_ANSWER" = "N" ] && [ "$JOERN_PROMPT_ANSWER" = "n" ]; then
 	exit 0
     fi
 
-    echo -n "Enter an install location or press enter for the default ($JOERN_DEFAULT_INSTALL_DIR): "
+    printf '%s' "Enter an install location or press enter for the default ($JOERN_DEFAULT_INSTALL_DIR): "
     read -r JOERN_INSTALL_DIR
 
     if [ "$JOERN_INSTALL_DIR" = "" ]; then
 	JOERN_INSTALL_DIR=$JOERN_DEFAULT_INSTALL_DIR
     fi
 
-    echo -n "Would you like to create a symlink to the Joern tools? [y/N]: "
+    printf "Would you like to create a symlink to the Joern tools? [y/N]: "
     read -r JOERN_LINK_ANSWER
 
     if [ "$JOERN_LINK_ANSWER" = "Y" ] || [ "$JOERN_LINK_ANSWER" = "y" ]; then
-	echo -n "Where would you like to link the Joern tools? (default $JOERN_DEFAULT_LINK_DIR): "
+	printf '%s' "Where would you like to link the Joern tools? (default $JOERN_DEFAULT_LINK_DIR): "
 	read -r JOERN_LINK_DIR
 	if [ "$JOERN_LINK_DIR" = "" ]; then
 	    JOERN_LINK_DIR=$JOERN_DEFAULT_LINK_DIR
 	fi
     fi
 
-    echo -n "Please enter a Joern version/tag or press enter for the latest version: "
+    printf "Please enter a Joern version/tag or press enter for the latest version: "
     read -r JOERN_VERSION
 
 fi
@@ -87,7 +87,7 @@ unzip -qo -d "$JOERN_INSTALL_DIR" "$SCRIPT_ABS_DIR"/joern-cli.zip
 rm "$SCRIPT_ABS_DIR"/joern-cli.zip
 
 # Link to JOERN_LINK_DIR if desired by the user
-if [ -n "${JOERN_LINK_DIR+dummy}" ] && [ "$(whoami)" == "root" ]; then
+if [ -n "${JOERN_LINK_DIR+dummy}" ] && [ "$(whoami)" = "root" ]; then
   echo "Creating symlinks to Joern tools in $JOERN_LINK_DIR"
   ln -sf "$JOERN_INSTALL_DIR"/joern-cli/joern "$JOERN_LINK_DIR" || true
   ln -sf "$JOERN_INSTALL_DIR"/joern-cli/joern-cpg2scpg "$JOERN_LINK_DIR" || true
@@ -95,8 +95,8 @@ if [ -n "${JOERN_LINK_DIR+dummy}" ] && [ "$(whoami)" == "root" ]; then
 fi
 
 echo "Installing default queries"
-CURDIR=`pwd`
+CURDIR=$(pwd)
 cd $JOERN_INSTALL_DIR/joern-cli
 ./joern-scan --updatedb
-cd $CURDIR
+cd "$CURDIR"
 echo "Install complete!"


### PR DESCRIPTION
`joern-install.sh` always fetches the latest release and installs it and github takes about 20 minutes to deliver that release to Germany. That's making iterative work on the installer a pain. It also means that one can't test-install a modified local version of joern. To fix both of these problems, I'm introducing a `--no-download` flag that runs joern-install.sh for the local source code.