### PR TITLE
Allow specifying `--dbversion latest` in `--updatedb`

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -122,7 +122,11 @@ object JoernScan extends App with BridgeBase {
   }
 
   private def urlForVersion(version: String): String = {
-    s"https://github.com/joernio/query-database/releases/download/v$version/querydb.zip"
+    if (version == "latest") {
+      "https://github.com/joernio/query-database/releases/latest/download/querydb.zip"
+    } else {
+      s"https://github.com/joernio/query-database/releases/download/v$version/querydb.zip"
+    }
   }
 
   override protected def predefPlus(lines: List[String]): String = AmmoniteBridge.predefPlus(lines)


### PR DESCRIPTION
By default, --updatedb will download the version specified in the Joern release, however, it allows the user to alternatively specify a version. We now also allow supplying "latest", saving the user from needing to check what the latest version is. It should be noted, however, that the latest version of querydb may not be compatible with the installed version of joern.