### PR TITLE
Simplified Java file intake

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
-  "io.github.plume-oss"    % "plume" % "0.1.5" exclude("io.github.plume-oss", "cpgconv"),
+  "io.github.plume-oss"    % "plume" % "0.1.6" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",
   "com.lihaoyi" %% "ammonite" % "2.3.8-4-88785969" cross CrossVersion.full,

--- a/joern-cli/src/main/scala/io/shiftleft/joern/plume/PlumeCpgGenerator.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/plume/PlumeCpgGenerator.scala
@@ -17,10 +17,8 @@ object PlumeCpgGenerator {
     try {
       existing.foreach { inputPath =>
         val inFile = File(inputPath)
-        if (inFile.isDirectory) {
-          createCpgForDirectory(inputPath, config)
-        } else if (inFile.isRegularFile) {
-          createCpgForArchive(inputPath, config)
+        if (inFile.isDirectory || inFile.isRegularFile) {
+          createCpgForInputPath(inputPath, config)
         } else {
           Try { throw new RuntimeException(s"$inputPath is neither a file nor a directory") }
         }
@@ -31,8 +29,8 @@ object PlumeCpgGenerator {
     }
   }
 
-  private def createCpgForDirectory(inputPath: String, config: JoernParse.ParserConfig): Unit = {
-    println(s"Creating CPG for directory: $inputPath")
+  private def createCpgForInputPath(inputPath: String, config: JoernParse.ParserConfig): Unit = {
+    println(s"Creating CPG for: $inputPath")
     Using(DriverFactory.invoke(GraphDatabase.OVERFLOWDB).asInstanceOf[OverflowDbDriver]) { driver =>
       deleteIfExists(config.outputCpgFile)
       driver.setStorageLocation(config.outputCpgFile)
@@ -43,14 +41,6 @@ object PlumeCpgGenerator {
       case Success(_)   =>
       case Failure(exc) => throw exc
     }
-  }
-
-  private def createCpgForArchive(inputPath: String, config: JoernParse.ParserConfig): Unit = {
-    println("Archive detected. Extracting.")
-    val dir = File(inputPath).unzip()
-    dir.listRecursively.foreach(println)
-    createCpgForDirectory(dir.path.toString, config)
-    dir.delete()
   }
 
   private def deleteIfExists(fileName: String) = {


### PR DESCRIPTION
- Upgraded Plume version (this one supports JAR intake directly)
- Combined functions that handle JAR and directory separately into one case
- Internally, Plume v0.1.6 unzips the JAR file to `$TEMP/plume` where it then reads it in as a directory