### PR TITLE
fix gitignore for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ $RECYCLE.BIN/
 
 /.bsp
 /gnupg-*
+/joern-cli/${sys:LOG_DIR}/


### PR DESCRIPTION
This stopped us from releasing after the plume upgrade. It would probably be better to configure the log dir via env vars, but this works too...

re https://github.com/ShiftLeftSecurity/joern/pull/481