### PR TITLE
Re-introduce Plume upgrade

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
-  "io.github.plume-oss"    % "plume" % "0.2.6" exclude("io.github.plume-oss", "cpgconv"),
+  "io.github.plume-oss"    % "plume" % "0.3.0" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",
   "com.lihaoyi" %% "ammonite" % "2.3.8-4-88785969" cross CrossVersion.full,


### PR DESCRIPTION
The revert at 31b18bff97019929b47ed115e6844c44a4f60b4d was intended to
turn the build back to green, but the change at
56e2ff6f338e9423da7e1441c3d8de5ebecdd364 already did it.