### PR TITLE
Upgrade Plume to v0.4.0

### DIFF
--- a/joern-cli/build.sbt
+++ b/joern-cli/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "console" % Versions.cpgVersion % Test classifier "tests",
   "io.shiftleft" %% "dataflowengineoss" % Versions.cpgVersion,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.cpgVersion,
-  "io.github.plume-oss"    % "plume" % "0.3.10" exclude("io.github.plume-oss", "cpgconv"),
+  "io.github.plume-oss"    % "plume" % "0.4.0" exclude("io.github.plume-oss", "cpgconv"),
 
   "com.lihaoyi" %% "requests" % "0.6.5",
   "com.lihaoyi" %% "ammonite" % "2.3.8-4-88785969" cross CrossVersion.full,


### PR DESCRIPTION
### Added

- `ArrayRef` now gets projected as an `Operators.indexAccess` call with index and base identifier as the arguments.
- `InstanceOfExpr` now gets projected as an `Operators.instanceOf` call.
- `LengthExpr` now gets projected as an `Operators.lengthOf` call. This is a custom operator
- `MonitorStmt` now gets projected as an `Unknown` vertex.
- `NegExpr` now gets projected as an `Operators.minus` call.

### Fixed

- Crashing passes from making the program hang. Exceptions are caught, logged, and the build is saved as far as it got.

### Changed

- `ThrowStmt` is now an `Unknown` vertex where control flow ends at.
- `NewArrayExpr` is now an `Unknown` vertex.