### PR TITLE
Allow specifying language in joern-scan.

### DIFF
--- a/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
+++ b/joern-cli/src/main/scala/io/shiftleft/joern/JoernScan.scala
@@ -24,7 +24,8 @@ case class JoernScanConfig(src: String = "",
                            queryDbVersion: String = JoernScanConfig.defaultDbVersion,
                            maxCallDepth: Int = 2,
                            onlyNames: String = "",
-                           onlyTags: String = "")
+                           onlyTags: String = "",
+                           language: Option[String] = None)
 
 object JoernScan extends App with BridgeBase {
 
@@ -70,6 +71,9 @@ object JoernScan extends App with BridgeBase {
         .action((x, c) => c.copy(maxCallDepth = x))
         .text("Set call depth for interprocedural analysis")
 
+      opt[String]("language")
+        .action((x, c) => c.copy(language = Some(x)))
+        .text("Source language")
     }
   }.parse(args, JoernScanConfig())
 
@@ -92,7 +96,11 @@ object JoernScan extends App with BridgeBase {
       Scan.defaultOpts.maxCallDepth = config.maxCallDepth
       val shellConfig = io.shiftleft.console
         .Config()
-        .copy(pluginToRun = Some("scan"), src = Some(config.src), overwrite = config.overwrite, store = config.store)
+        .copy(pluginToRun = Some("scan"),
+              src = Some(config.src),
+              overwrite = config.overwrite,
+              store = config.store,
+              language = config.language)
       runAmmonite(shellConfig, JoernProduct)
     }
   }


### PR DESCRIPTION
Previously, `joern-scan` attempted to guess the source language, and it was frequently wrong. With this PR, we can specify the language via the `--language` flag.