### PR TITLE
read cpgVersion from file rather than env var

### DIFF
--- a/joern-cli/src/universal/schema-extender/build.sbt
+++ b/joern-cli/src/universal/schema-extender/build.sbt
@@ -1,6 +1,6 @@
 name := "schema-extender"
 
-val cpgVersion = sys.env.get("CPG_VERSION").getOrElse("system env `CPG_VERSION` must be defined, but isn't...")
+val cpgVersion = IO.read(file("cpg-version"))
 
 val generateDomainClasses = taskKey[Seq[File]]("generate overflowdb domain classes for our schema")
 


### PR DESCRIPTION
... mostly so that works seamlessly within an IDE